### PR TITLE
Replaced <b> by <h3> in FAQ and LINKS pages

### DIFF
--- a/openraData/templates/faq.html
+++ b/openraData/templates/faq.html
@@ -1,4 +1,4 @@
-<br/><b>What is this website about?</b><br/>
+<br/><h3>What is this website about?</h3><br/>
 This website has been created to provide OpenRA community a place to share files related to this game such as:
 <ul>
 <li> Maps (standard, advanced and missions</li>
@@ -12,7 +12,7 @@ This website has been created to provide OpenRA community a place to share files
 
 
 <br/><br/>
-<b>Why am I obliged to upload my map on this website?</b><br/>
+<h3>Why am I obliged to upload my map on this website?</h3><br/>
 If you created a new map and want to play it with other players, you just have to:
 <ul>
 <li> Upload it on this website</li>
@@ -22,7 +22,7 @@ If you created a new map and want to play it with other players, you just have t
 
 
 <br/><br/>
-<b>What are the rules regarding what I can upload on the site?</b><br/>
+<h3>What are the rules regarding what I can upload on the site?</h3><br/>
 <ul>
 <li> We ask you to upload only OpenRA related files</li>
 <li> You are not allowed to steal someone else's work and publish it here under your name</li>
@@ -32,20 +32,20 @@ If you created a new map and want to play it with other players, you just have t
 
 
 <br/><br/>
-<b>How can I report a Copyright infringement?</b><br/>
+<h3>How can I report a Copyright infringement?</h3><br/>
 Go to the page where you saw the file and click on the link "Report Copyright Infringement" or contact us at OpenRA <a  target="_blank" href="http://webchat.freenode.net/?channels=openra">IRC channel</a>
 <br/><br/>
 
 
 <br/><br/>
-<b>How can I create a map?</b><br/>
+<h3>How can I create a map?</h3><br/>
 You can find tutorials &amp; documentation at OpenRA wiki page: 
 <a target="_blank" href="https://github.com/OpenRA/OpenRA/wiki/Mapping">https://github.com/OpenRA/OpenRA/wiki/Mapping</a>
 <br/><br/>
 
 
 <br/><br/>
-<b>How to create a SHP unit?</b><br/>
+<h3>How to create a SHP unit?</h3><br/>
 You can find a tutorial on this page: 
 <a target="_blank" href="https://github.com/OpenRA/OpenRA/wiki/Pixelart">https://github.com/OpenRA/OpenRA/wiki/Pixelart</a>
 <br/><br/>

--- a/openraData/templates/links.html
+++ b/openraData/templates/links.html
@@ -1,35 +1,35 @@
-<br /><b>Official website:</b><br />
+<br /><h3>Official website:</h3><br />
 <a target="_blank" href="http://open-ra.org/">http://open-ra.org/</a> (official website)<br />
 <a target="_blank" href="http://openra.res0l.net/statistics/">http://open-ra.org/statistics/</a> (open-ra.org stats)<br />
 <a target="_blank" href="http://stats.pingdom.com/syygqlg6525r/788293">http://stats.pingdom.com/syygqlg6525r/788293<a> (Pingdom Uptime and Latency Measurement)<br /><br />
 
-<b>IRC:</b><br />
+<h3>IRC:</h3><br />
 <a target="_blank" href="http://webchat.freenode.net/?channels=openra">http://webchat.freenode.net/?channels=openra</a> (live chat)<br />
 <a target="_blank" href="http://logs.ihptru.net/">http://logs.ihptru.net/</a> (IRC logs)<br />
 <a target="_blank" href="http://logs.ihptru.net/stats/index.html">http://logs.ihptru.net/stats/index.html</a> (IRC channel stats)<br /><br />
 
-<b>Master Server:</b><br />
+<h3>Master Server:</h3><br />
 <a target="_blank" href="http://openra.ipdx.ru/graphs.html">http://openra.ipdx.ru/graphs.html</a> (Player activity graphs)<br />
 <a target="_blank" href="http://stats.pingdom.com/zaegmvlagqpe/788265">http://stats.pingdom.com/zaegmvlagqpe/788265<a> (Pingdom Uptime and Latency Measurement)<br /><br />
 
-<b>Forums:</b><br />
+<h3>Forums:</h3><br />
 <a target="_blank" href="http://www.sleipnirstuff.com/forum/viewforum.php?f=80">http://www.sleipnirstuff.com/forum/viewforum.php?f=80</a> (official)<br />
 <a target="_blank" href="http://www.ppmsite.com/forum/index.php?f=929">http://www.ppmsite.com/forum/index.php?f=929</a> (ppmsite)<br /><br />
 
-<b>Social sites:</b><br/>
+<h3>Social sites:</h3><br/>
 <a target="_blank" href="http://www.desura.com/games/openra">http://www.desura.com/games/openra</a><br />
 <a target="_blank" href="http://www.moddb.com/games/openra">http://www.moddb.com/games/openra</a><br />
 <a target="_blank" href="https://twitter.com/openRA">https://twitter.com/openRA</a><br />
 <a target="_blank" href="https://plus.google.com/s/openra">https://plus.google.com/s/openra</a><br />
 <a target="_blank" href="https://www.facebook.com/openra">https://www.facebook.com/openra</a><br /><br />
 
-<b>Wiki:</b><br />
+<h3>Wiki:</h3><br />
 <a target="_blank" href="https://github.com/OpenRA/OpenRA/wiki">https://github.com/OpenRA/OpenRA/wiki</a><br /><br />
 
-<b>Games:</b><br/>
+<h3>Games:</h3><br/>
 <a target="_blank" href="http://openra.res0l.net/games/">http://openra.res0l.net/games/</a> (current games)<br /><br />
 
-<b>This Website:</b><br/>
+<h3>This Website:</h3><br/>
 <a target="_blank" href="https://github.com/ihptru/OpenRA-Content-Engine/wiki">https://github.com/ihptru/OpenRA-Content-Engine/wiki</a> (wiki)<br />
 <a target="_blank" href="https://github.com/ihptru/OpenRA-Content-Engine/issues?state=open">https://github.com/ihptru/OpenRA-Content-Engine/issues?state=open</a> (issue tracker)<br />
 <a target="_blank" href="http://openra.res0l.net/statistics/">http://openra.res0l.net/statistics/</a> (webserver stats)<br />


### PR DESCRIPTION
Replaced < b > by < h3 > in FAQ and LINKS pages
... to match the Assets.html page layout.
