### PR TITLE
CC license spelling

### DIFF
--- a/openraData/templates/displayMap.html
+++ b/openraData/templates/displayMap.html
@@ -173,7 +173,7 @@
                                     <img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/{{icons}}/4.0/88x31.png" />
                                 </a>
                             </div>
-                            <div class="license_text left">This work is licensed under a <a target="_blank" rel="license" href="http://creativecommons.org/licenses/{{icons}}/4.0/deed.en_US">Creative Commons {{license}}</a>.</div>
+                            <div class="license_text left">Some rights reserved: <a target="_blank" rel="license" href="http://creativecommons.org/licenses/{{icons}}/4.0/deed.en_US">Creative Commons {{license}}</a>.</div>
                             <div class="clear"></div>
                         {% if request.user.is_authenticated %}
                             {% if reported == False %}


### PR DESCRIPTION
It currently says

> This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International.

with words missing and the indefinite article may also sound strange to native speakers so I replaced this.
