### PR TITLE
Change links to the new openra.net domain

### DIFF
--- a/openraData/templates/links.html
+++ b/openraData/templates/links.html
@@ -7,15 +7,15 @@
                 </ul>
                 <h3>Official OpenRA website:</h3>
                 <ul>
-                    <li><a target="_blank" href="http://open-ra.org/">http://open-ra.org/</a> (official website)</li>
-                    <li><a target="_blank" href="http://openra.res0l.net/statistics/">http://open-ra.org/statistics/</a> (open-ra.org stats)</li>
+                    <li><a target="_blank" href="http://www.openra.net/">http://www.openra.net/</a> (official website)</li>
+                    <li><a target="_blank" href="http://openra.net/games/">http://openra.net/games/</a> (current games)</li>
                     <li><a target="_blank" href="http://stats.pingdom.com/syygqlg6525r/788293">http://stats.pingdom.com/syygqlg6525r/788293</a> (Pingdom Uptime and Latency Measurement)</li>
                 </ul>
                 <h3>IRC:</h3>
                 <ul>
                     <li><a target="_blank" href="http://webchat.freenode.net/?channels=openra">http://webchat.freenode.net/?channels=openra</a> (live chat)</li>
-                    <li><a target="_blank" href="http://logs.ihptru.net/">http://logs.ihptru.net/</a> (IRC logs)</li>
-                    <li><a target="_blank" href="http://logs.ihptru.net/stats/index.html">http://logs.ihptru.net/stats/index.html</a> (IRC channel stats)</li>
+                    <li><a target="_blank" href="http://logs.openra.net/">http://logs.openra.net/</a> (IRC logs)</li>
+                    <li><a target="_blank" href="http://logs.openra.net/stats/index.html">http://logs.openra.net/stats/index.html</a> (IRC channel stats)</li>
                 </ul>
                 <h3>Master Server:</h3>
                 <ul>
@@ -39,9 +39,12 @@
                 <ul>
                     <li><a target="_blank" href="http://wiki.openra.net">http://wiki.openra.net</a></li>
                 </ul>
-                <h3>Other:</h3>
+                <h3>Bugs:</h3>
                 <ul>
-                    <li><a target="_blank" href="http://openra.res0l.net/games/">http://openra.res0l.net/games/</a> (current games)</li>
-                    <li><a target="_blank" href="http://aaronfranks.com/openra_chart/">http://aaronfranks.com/openra_chart/</a> Unit costs and tech tree</li>
+                    <li><a target="_blank" href="http://bugs.openra.net">http://bugs.openra.net</a></li>
+                </ul>
+                <h3>Thirdparty:</h3>
+                <ul>
+                    <li><a target="_blank" href="af.github.io/openra_chart/">af.github.io/openra_chart/</a> Unit costs and tech tree</li>
                 </ul>
             </div>


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRAWeb/pull/126
