### PR TITLE
Fixed link to the static activity graphs

### DIFF
--- a/openraData/templates/links.html
+++ b/openraData/templates/links.html
@@ -22,7 +22,7 @@
         </ul>
         <h3>Master Server:</h3>
         <ul>
-            <li><a target="_blank" href="http://openra.ipdx.ru/graphs.html">http://openra.ipdx.ru/graphs.html</a> (Player activity graphs)</li>
+            <li><a target="_blank" href="http://activity.openra.net/">http://activity.openra.net/</a> (Player activity graphs)</li>
             <li><a target="_blank" href="http://stats.pingdom.com/zaegmvlagqpe/788265">http://stats.pingdom.com/zaegmvlagqpe/788265</a> (Pingdom Uptime and Latency Measurement)</li>
         </ul>
         <h3>Forums:</h3>


### PR DESCRIPTION
It is http://activity.openra.net/ now for quite a while.