### PR TITLE
Added the Pingdom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 Django tools and applications to serve OpenRA Resource Center
+
+* Uptime and latency monitoring: http://stats.pingdom.com/syygqlg6525r/1950606


### PR DESCRIPTION
The friendly people from @Pingdom sponsored us uptime monitoring with a public status page.