### PR TITLE
Add a basic search to the map API

### DIFF
--- a/openra/urls.py
+++ b/openra/urls.py
@@ -106,6 +106,7 @@ urlpatterns = [
     url(r'^map/(?P<arg>\w+)/(?P<arg1>[^/]+)/(?P<arg2>\-?\w+)/?$', api.mapAPI, name='mapAPI_list'),
     url(r'^map/(?P<arg>\w+)/(?P<arg1>[^/]+)/(?P<arg2>\-?\w+)/(?P<arg3>[^/]+)/?$', api.mapAPI, name='mapAPI_list_strict'),
     url(r'^map/(?P<arg>\w+)/(?P<arg1>[^/]+)/(?P<arg2>\-?\w+)/(?P<arg3>[^/]+)/(?P<arg4>\w+)/?$', api.mapAPI, name='mapAPI_list_strict'),
+    url(r'^map/(?P<arg>\w+)/(?P<arg1>[^/]+)/(?P<arg2>\-?\w+)/(?P<arg3>[^/]+)/(?P<arg4>\w+)/?/(?P<arg5>\w+)/?$', api.mapAPI, name='mapAPI_search'),
 
 
     url(r'^favicon\.ico$', RedirectView.as_view(url='/static/favicon.ico')),


### PR DESCRIPTION
Allows maps to be searched with the API using URLs in the following format:

/map/search/[mod]/[search_by]/[page]/[return_format]/[search_string]