### PR TITLE
Simplify engine version logic

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,9 +62,6 @@ $ pip install -r requirements.txt
  * Edit Database connection settings
  * Change ```OPENRA_ROOT_PATH```, using example above, it will be ```/home/openra/engines/```
  * Change ```OPENRA_VERSIONS```, it will be just version tag names
- * Change ```OPENRA_BLEED_HASH_FILE_PATH``` to specify path to text file where you store git hash of compiled bleed version
- * Change ```OPENRA_BLEED_PARSER``` to specify directory where bleed version is compiled
-
 
 
 ### Initialize django database (this will create all tables)

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -34,13 +34,12 @@ class MapHandlers():
     def ProcessUploading(self, user_id, f, post, rev=1, pre_r=0):
 
         parser_to_db = list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]  # default parser = the latest
-        parser = os.path.join(settings.OPENRA_ROOT_PATH, parser_to_db)
-
         if post.get("parser", None) is not None:
+            if post['parser'] not in settings.OPENRA_VERSIONS.values():
+                return 'Failed. Invalid parser'
             parser_to_db = post['parser']
-            parser = os.path.join(settings.OPENRA_ROOT_PATH, parser_to_db)
-            if 'git' in parser:
-                parser = settings.OPENRA_BLEED_PARSER
+
+        parser = os.path.join(settings.OPENRA_ROOT_PATH, parser_to_db)
 
         if pre_r != 0:
             mapObject = Maps.objects.filter(id=pre_r, user_id=user_id)

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -32,10 +32,9 @@ class MapHandlers():
         self.legacy_map = False
 
     def ProcessUploading(self, user_id, f, post, rev=1, pre_r=0):
-
-        parser_to_db = list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]  # default parser = the latest
+        parser_to_db = settings.OPENRA_VERSIONS[0]
         if post.get("parser", None) is not None:
-            if post['parser'] not in settings.OPENRA_VERSIONS.values():
+            if post['parser'] not in settings.OPENRA_VERSIONS:
                 return 'Failed. Invalid parser'
             parser_to_db = post['parser']
 
@@ -215,7 +214,7 @@ class MapHandlers():
             pass
         z.close()
 
-    def GetHash(self, filepath="", parser=settings.OPENRA_ROOT_PATH + list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]):
+    def GetHash(self, filepath="", parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0]):
         if filepath == "":
             filepath = self.map_full_path_filename
 
@@ -228,7 +227,7 @@ class MapHandlers():
 
         self.maphash = proc[0].decode().strip()
 
-    def GenerateMinimap(self, game_mod, parser=settings.OPENRA_ROOT_PATH + list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]):
+    def GenerateMinimap(self, game_mod, parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0]):
 
         os.chmod(self.map_full_path_filename, 0o444)
         command = 'mono --debug %s %s --map-preview %s' % (os.path.join(parser, 'OpenRA.Utility.exe'), game_mod, self.map_full_path_filename)
@@ -243,7 +242,7 @@ class MapHandlers():
         except:
             pass  # failed to generate minimap
 
-    def LegacyImport(self, mapPath, parser=settings.OPENRA_ROOT_PATH + list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]):
+    def LegacyImport(self, mapPath, parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0]):
         for mod in ['ra', 'cnc']:
 
             assign_mod = mod

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -227,21 +227,6 @@ class MapHandlers():
 
         self.maphash = proc[0].decode().strip()
 
-    def GenerateMinimap(self, game_mod, parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0]):
-
-        os.chmod(self.map_full_path_filename, 0o444)
-        command = 'mono --debug %s %s --map-preview %s' % (os.path.join(parser, 'OpenRA.Utility.exe'), game_mod, self.map_full_path_filename)
-        proc = Popen(command.split(), stdout=PIPE).communicate()
-        os.chmod(self.map_full_path_filename, 0o644)
-
-        try:
-            shutil.move(
-                os.path.join(parser, self.preview_filename),
-                os.path.join(self.map_full_path_directory, os.path.splitext(self.preview_filename)[0] + "-mini.png"))
-            self.minimap_generated = True
-        except:
-            pass  # failed to generate minimap
-
     def LegacyImport(self, mapPath, parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0]):
         for mod in ['ra', 'cnc']:
 

--- a/openra/misc.py
+++ b/openra/misc.py
@@ -306,8 +306,7 @@ def map_filter(request, mapObject):
     filter_prepare['categories'] = sorted(MapCategories.objects.values_list('category_name', flat=True))
     filter_prepare['formats'] = sorted(Maps.objects.values_list('mapformat', flat=True).distinct())
     filter_prepare['formats'] = [str(val) for val in filter_prepare['formats']]
-    filter_prepare['parsers'] = Maps.objects.values_list('parser', flat=True).distinct()
-    filter_prepare['parsers'] = sorted([val for val in filter_prepare['parsers'] if 'git' not in val])
+    filter_prepare['parsers'] = sorted(Maps.objects.values_list('parser', flat=True).distinct())
     filter_prepare['tilesets'] = sorted(Maps.objects.values_list('tileset', flat=True).distinct())
 
     filter_prepare['sort_by'] = [
@@ -381,17 +380,7 @@ def map_filter(request, mapObject):
 
     # filter by engine parser
     if selected_filter['parser'] and 'any' not in selected_filter['parser']:
-        mapObject_copy0 = copy.copy(mapObject)
-        mapObject_copy1 = copy.copy(mapObject)
-
-        mapObject_copy0 = mapObject_copy0.filter(parser__in=selected_filter['parser'])
-
-        if 'bleed' in selected_filter['parser']:
-            mapObject_copy1 = mapObject_copy1.filter(parser__contains='git')
-
-            mapObject = mapObject_copy0 | mapObject_copy1
-        else:
-            mapObject = mapObject_copy0
+        mapObject = mapObject.filter(parser__in=selected_filter['parser'])
 
     # filter by tileset
     if selected_filter['tileset'] and 'any' not in selected_filter['tileset']:

--- a/openra/misc.py
+++ b/openra/misc.py
@@ -413,7 +413,7 @@ def map_filter(request, mapObject):
 
     # filter: show only last revisions of maps where parser is not equal to the latest official
     if selected_filter['outdated'] == 'on':
-        latest_official_parser = list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]
+        latest_official_parser = settings.OPENRA_VERSIONS[0]
         mapObject = mapObject.filter(next_rev=0).exclude(parser=latest_official_parser)
 
     # filter options for maps with problems

--- a/openra/settings.py.example
+++ b/openra/settings.py.example
@@ -168,18 +168,10 @@ OPENRA_ROOT_PATH = ''
 
 # OpenRA Versions matching their directory names
 OPENRA_VERSIONS = {
-    3: 'release-20151224',
-    2: 'release-20150919',
-    1: 'release-20150614',
-    0: 'bleed',  # just a name, see OPENRA_BLEED_PARSER setting
+    2: 'release-20151224',
+    1: 'release-20150919',
+    0: 'release-20150614',
 }
-
-# Path to file which stores HASH of the latest `bleed` version
-OPENRA_BLEED_HASH_FILE_PATH = ''
-
-# `bleed` parser  directory is being updated by external script once new commit is pushed and has different structure (full path to directory)
-OPENRA_BLEED_PARSER = ''
-
 
 # Email address (FROM) in our custom mail methods
 ADMIN_EMAIL_FROM = ''

--- a/openra/settings.py.example
+++ b/openra/settings.py.example
@@ -166,12 +166,13 @@ ACCOUNT_ACTIVATION_DAYS = 7
 # Path to directory where OpenRA versions are stored
 OPENRA_ROOT_PATH = ''
 
-# OpenRA Versions matching their directory names
-OPENRA_VERSIONS = {
-    2: 'release-20151224',
-    1: 'release-20150919',
-    0: 'release-20150614',
-}
+# OpenRA versions matching their directory names
+# Reverse chronological order - newer versions must be listed first!
+OPENRA_VERSIONS = [
+    'release-20180307',
+    'release-20180218',
+    'release-20171014',
+]
 
 # Email address (FROM) in our custom mail methods
 ADMIN_EMAIL_FROM = ''

--- a/openra/templates/maps.html
+++ b/openra/templates/maps.html
@@ -40,7 +40,6 @@
 				<span class="">Parsed by:</span>
 				<select name="parser" multiple class="noscroll">
 					<option value="any" {% if 'any' in selected_filter.parser %}selected{% endif %}>any</option>
-					<option value="bleed" {% if 'bleed' in selected_filter.parser %}selected{% endif %}>bleed (any)</option>
 					{% for parser in filter_prepare.parsers %}
 						<option value="{{parser}}" {% if parser in selected_filter.parser %}selected{% endif %}>{{parser}}</option>
 					{% endfor %}

--- a/openra/templates/maps_author.html
+++ b/openra/templates/maps_author.html
@@ -39,7 +39,6 @@
 				<span class="">Parsed by:</span>
 				<select name="parser" multiple class="noscroll">
 					<option value="any" {% if 'any' in selected_filter.parser %}selected{% endif %}>any</option>
-					<option value="bleed" {% if 'bleed' in selected_filter.parser %}selected{% endif %}>bleed (any)</option>
 					{% for parser in filter_prepare.parsers %}
 						<option value="{{parser}}" {% if parser in selected_filter.parser %}selected{% endif %}>{{parser}}</option>
 					{% endfor %}

--- a/openra/templates/maps_uploader.html
+++ b/openra/templates/maps_uploader.html
@@ -39,7 +39,6 @@
 				<span class="">Parsed by:</span>
 				<select name="parser" multiple class="noscroll">
 					<option value="any" {% if 'any' in selected_filter.parser %}selected{% endif %}>any</option>
-					<option value="bleed" {% if 'bleed' in selected_filter.parser %}selected{% endif %}>bleed (any)</option>
 					{% for parser in filter_prepare.parsers %}
 						<option value="{{parser}}" {% if parser in selected_filter.parser %}selected{% endif %}>{{parser}}</option>
 					{% endfor %}

--- a/openra/templates/upgradeMap.html
+++ b/openra/templates/upgradeMap.html
@@ -32,7 +32,7 @@
 			<p>Here you can upgrade your map to newer OpenRA engine version.</p>
 			<p>Upgrade is available:</p>
 			<ul>
-				<li>if map is parsed by release or playtest, bleed is not supported</li>
+				<li>if map was parsed by a compatible engine version</li>
 				<li>if it's the latest revision of the map</li>
 				<li>if there is newer OpenRA engine version compared to one that your map was parsed by</li>
 			</ul>

--- a/openra/templates/uploadMap.html
+++ b/openra/templates/uploadMap.html
@@ -12,8 +12,6 @@
 			$('.upload-map-form-parser option:first-child').attr("selected", "selected");
 
 			$('.upload-map-form-parser option:first-child').append(' (the latest published)')
-
-			$('.upload-map-form-parser option:contains("bleed")').append( ' (development)')
 		});
 	</script>
 
@@ -50,11 +48,7 @@
 					Parse with OpenRA version<span class="red">**</span>:<br />
 					<select name="parser" size="4">
 						{% for parser in parsers %}
-							{% if parser == 'bleed' %}
-								<option value="{{ bleed_tag }}">bleed ({{ bleed_tag }})</option>
-							{% else %}
-								<option value="{{ parser }}">{{ parser }}</option>
-							{% endif %}
+							<option value="{{ parser }}">{{ parser }}</option>
 						{% endfor %}
 					</select>
 				</div>

--- a/openra/utility.py
+++ b/openra/utility.py
@@ -56,10 +56,9 @@ def map_upgrade(mapObject, engine, parser=list(reversed(list(settings.OPENRA_VER
         ###
 
         if item.parser != "":
-            if 'git' not in item.parser:
-                parser_eng = item.parser.split('-')[1]
-                if int(engine) > int(parser_eng):
-                    engine = parser_eng
+            parser_eng = item.parser.split('-')[1]
+            if int(engine) > int(parser_eng):
+                engine = parser_eng
 
         command = 'mono --debug %s %s --upgrade-map %s %s' % (os.path.join(parser, 'OpenRA.Utility.exe'), item.game_mod, os.path.join(ora_temp_dir_name, filename), engine)
         print(command)
@@ -473,23 +472,8 @@ def LintCheck(item, fullpath="", parser=settings.OPENRA_ROOT_PATH + list(reverse
     available_parsers = list(reversed(list(settings.OPENRA_VERSIONS.values())))
 
     for current_parser in available_parsers:
-        if current_parser == "bleed":
-
-            bleed_tag = None
-            if (settings.OPENRA_BLEED_HASH_FILE_PATH != '' and os.path.isfile(settings.OPENRA_BLEED_HASH_FILE_PATH)):
-                bleed_tag = open(settings.OPENRA_BLEED_HASH_FILE_PATH, 'r')
-                bleed_tag = 'git-' + bleed_tag.readline().strip()[0:7]
-            if bleed_tag is None:
-                continue
-
-            if not os.path.isfile(os.path.join(settings.OPENRA_BLEED_PARSER, 'OpenRA.Utility.exe')):
-                continue
-
-            current_parser_to_db = bleed_tag
-            current_parser_path = settings.OPENRA_BLEED_PARSER
-        else:
-            current_parser_to_db = current_parser
-            current_parser_path = settings.OPENRA_ROOT_PATH + current_parser
+        current_parser_to_db = current_parser
+        current_parser_path = settings.OPENRA_ROOT_PATH + current_parser
 
         if upgrade_with_new_rev and current_parser_path != parser:
             continue
@@ -535,11 +519,8 @@ def LintCheck(item, fullpath="", parser=settings.OPENRA_ROOT_PATH + list(reverse
 
         if not upgrade_with_new_rev:
             lintObject = Lints.objects.filter(map_id=item.id, version_tag=current_parser_to_db)
-            lintObjectGit = Lints.objects.filter(map_id=item.id, version_tag__startswith='git')
             if lintObject:
                 Lints.objects.filter(map_id=item.id, version_tag=current_parser_to_db).update(pass_status=passing, lint_output=output_to_db, posted=timezone.now())
-            elif lintObjectGit and current_parser_to_db.startswith('git'):
-                Lints.objects.filter(map_id=item.id, version_tag__startswith='git').update(pass_status=passing, lint_output=output_to_db, posted=timezone.now())
             else:
                 lint_transac = Lints(
                     item_type="maps",

--- a/openra/utility.py
+++ b/openra/utility.py
@@ -15,7 +15,7 @@ from openra.models import Maps, Lints, MapCategories
 from openra import misc
 
 
-def map_upgrade(mapObject, engine, parser=list(reversed(list(settings.OPENRA_VERSIONS.values())))[0], new_rev_on_upgrade=True, upgrade_if_hash_matches=False, upgrade_if_lint_fails=False):
+def map_upgrade(mapObject, engine, parser=settings.OPENRA_VERSIONS[0], new_rev_on_upgrade=True, upgrade_if_hash_matches=False, upgrade_if_lint_fails=False):
 
     parser_to_db = parser
     parser = os.path.join(settings.OPENRA_ROOT_PATH, parser)
@@ -257,7 +257,7 @@ def map_upgrade(mapObject, engine, parser=list(reversed(list(settings.OPENRA_VER
     return upgraded_maps
 
 
-def recalculate_hash(item, fullpath="", parser=settings.OPENRA_ROOT_PATH + list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]):
+def recalculate_hash(item, fullpath="", parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0]):
 
     if fullpath == "":
 
@@ -413,7 +413,7 @@ def ReadYaml(item=False, fullpath=""):
     return {'response': map_data_ordered, 'error': False}
 
 
-def ReadRules(item=False, fullpath="", parser=settings.OPENRA_ROOT_PATH + list(reversed(list(settings.OPENRA_VERSIONS.values())))[0], game_mod="ra"):
+def ReadRules(item=False, fullpath="", parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0], game_mod="ra"):
 
     if fullpath == "":
         if item is False:
@@ -465,13 +465,11 @@ def UnzipMap(item, fullpath=""):
     return True
 
 
-def LintCheck(item, fullpath="", parser=settings.OPENRA_ROOT_PATH + list(reversed(list(settings.OPENRA_VERSIONS.values())))[0], upgrade_with_new_rev=False):
+def LintCheck(item, fullpath="", parser=settings.OPENRA_ROOT_PATH + settings.OPENRA_VERSIONS[0], upgrade_with_new_rev=False):
     # this function performs a Lint Check for map
     response = {'error': True, 'response': ''}
 
-    available_parsers = list(reversed(list(settings.OPENRA_VERSIONS.values())))
-
-    for current_parser in available_parsers:
+    for current_parser in settings.OPENRA_VERSIONS:
         current_parser_to_db = current_parser
         current_parser_path = settings.OPENRA_ROOT_PATH + current_parser
 

--- a/openra/views.py
+++ b/openra/views.py
@@ -555,8 +555,6 @@ def displayMap(request, arg):
     if not (request.user == mapObject.user or request.user.is_superuser):
         show_upgrade_map_button = False
 
-    if 'git' in mapObject.parser:
-        show_upgrade_map_button = False  # can't upgrade maps uploaded with bleed parser
     if mapObject.next_rev != 0:
         show_upgrade_map_button = False  # upgrade only the latest revision
 
@@ -617,17 +615,10 @@ def upgradeMap(request, arg):
     if mapObject[0].user != request.user:
         if not request.user.is_superuser:
             return HttpResponseRedirect('/maps/' + arg + '/')
-
-    if 'git' in mapObject[0].parser:
-        return HttpResponseRedirect('/maps/' + arg + '/')  # can't upgrade maps uploaded with bleed parser
-
     if mapObject[0].next_rev != 0:
         return HttpResponseRedirect('/maps/' + arg + '/')  # upgrade only the latest revision
 
     parsers = list(reversed(list(settings.OPENRA_VERSIONS.values())))
-    if 'bleed' in parsers:
-        parsers.remove('bleed')
-
     if mapObject[0].parser == parsers[0]:
         return HttpResponseRedirect('/maps/' + arg + '/')  # map is up-to-date
 
@@ -901,14 +892,6 @@ def uploadMap(request, previous_rev=0):
 
     parsers = list(reversed(list(settings.OPENRA_VERSIONS.values())))
 
-    bleed_tag = None
-    if (settings.OPENRA_BLEED_HASH_FILE_PATH != '' and os.path.isfile(settings.OPENRA_BLEED_HASH_FILE_PATH)):
-        bleed_tag = open(settings.OPENRA_BLEED_HASH_FILE_PATH, 'r')
-        bleed_tag = 'git-' + bleed_tag.readline().strip()[0:7]
-    if 'bleed' in parsers:
-        if not os.path.isfile(os.path.join(settings.OPENRA_BLEED_PARSER, 'OpenRA.Utility.exe')):
-            parsers.remove('bleed')
-
     template = loader.get_template('index.html')
     template_args = {
         'content': 'uploadMap.html',
@@ -919,7 +902,6 @@ def uploadMap(request, previous_rev=0):
         'previous_rev_title': previous_rev_title,
         'rev': rev,
         'parsers': parsers,
-        'bleed_tag': bleed_tag,
         'error_response': error_response,
     }
 

--- a/openra/views.py
+++ b/openra/views.py
@@ -558,7 +558,7 @@ def displayMap(request, arg):
     if mapObject.next_rev != 0:
         show_upgrade_map_button = False  # upgrade only the latest revision
 
-    if mapObject.parser == list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]:
+    if mapObject.parser == settings.OPENRA_VERSIONS[0]:
         show_upgrade_map_button = False  # map is up-to-date
     ###
 
@@ -566,8 +566,6 @@ def displayMap(request, arg):
     for sc_item in screenshots:
         if sc_item.map_preview:
             map_preview = sc_item
-
-    last_parser = list(reversed(list(settings.OPENRA_VERSIONS.values())))[0]
 
     license, icons = misc.selectLicenceInfo(mapObject)
     userObject = User.objects.get(pk=mapObject.user_id)
@@ -600,7 +598,7 @@ def displayMap(request, arg):
         'show_upgrade_map_button': show_upgrade_map_button,
         'map_preview': map_preview,
         'contains_shp': contains_shp,
-        'last_parser': last_parser,
+        'last_parser': settings.OPENRA_VERSIONS[0],
     }
     return StreamingHttpResponse(template.render(template_args, request))
 
@@ -618,8 +616,7 @@ def upgradeMap(request, arg):
     if mapObject[0].next_rev != 0:
         return HttpResponseRedirect('/maps/' + arg + '/')  # upgrade only the latest revision
 
-    parsers = list(reversed(list(settings.OPENRA_VERSIONS.values())))
-    if mapObject[0].parser == parsers[0]:
+    if mapObject[0].parser == settings.OPENRA_VERSIONS[0]:
         return HttpResponseRedirect('/maps/' + arg + '/')  # map is up-to-date
 
     ##########
@@ -650,7 +647,7 @@ def upgradeMap(request, arg):
         'request': request,
         'title': ' - Upgrade Map - ' + mapObject[0].title,
         'map': mapObject[0],
-        'parsers': parsers,
+        'parsers': settings.OPENRA_VERSIONS,
         'no_effect': no_effect,
         'failed_to_upgrade': failed_to_upgrade,
     }
@@ -890,8 +887,6 @@ def uploadMap(request, previous_rev=0):
                 if error_response is False:
                     return HttpResponseRedirect('/maps/' + uid + "/")
 
-    parsers = list(reversed(list(settings.OPENRA_VERSIONS.values())))
-
     template = loader.get_template('index.html')
     template_args = {
         'content': 'uploadMap.html',
@@ -901,7 +896,7 @@ def uploadMap(request, previous_rev=0):
         'previous_rev': previous_rev,
         'previous_rev_title': previous_rev_title,
         'rev': rev,
-        'parsers': parsers,
+        'parsers': settings.OPENRA_VERSIONS,
         'error_response': error_response,
     }
 

--- a/openra/views.py
+++ b/openra/views.py
@@ -560,6 +560,10 @@ def displayMap(request, arg):
 
     if mapObject.parser == settings.OPENRA_VERSIONS[0]:
         show_upgrade_map_button = False  # map is up-to-date
+
+    if mapObject.parser not in settings.OPENRA_VERSIONS:
+        show_upgrade_map_button = False  # map was not parsed with a compatible version
+
     ###
 
     map_preview = None
@@ -619,13 +623,15 @@ def upgradeMap(request, arg):
     if mapObject[0].parser == settings.OPENRA_VERSIONS[0]:
         return HttpResponseRedirect('/maps/' + arg + '/')  # map is up-to-date
 
+    if mapObject[0].parser not in settings.OPENRA_VERSIONS:
+        return HttpResponseRedirect('/maps/' + arg + '/')  # map was not parsed with a compatible parser
+
     ##########
     no_effect = False
     failed_to_upgrade = False
     if request.method == 'POST':
         upgrade_to_parser = request.POST.get('upgrade_to_parser', None)
-
-        if upgrade_to_parser:
+        if upgrade_to_parser and upgrade_to_parser in settings.OPENRA_VERSIONS:
 
             if int(mapObject[0].parser.split('-')[1]) >= int(upgrade_to_parser.split('-')[1]):
                 no_effect = True


### PR DESCRIPTION
This cleans up several things related to the definition and use of OPENRA_VERSIONS:
- The special-case bleed handling has been removed -- this has been disabled for a long time, I believe ever since the move to @Baxxster's servers.
- Updating to a newer parser is only allowed if the current parser is also defined in OPENRA_VERSIONS -- this provides an easy route for disabling updates for < 20171014, streamlining the way for the new update infrastructure (see #319).  In the future we can switch this over to the `--update-mod`'s update path list.
- Code cleanups.