### PR TITLE
Fix regressions from recent upload/API prs

### DIFF
--- a/openra/api.py
+++ b/openra/api.py
@@ -1,5 +1,4 @@
 import base64
-import html
 import json
 import os
 
@@ -27,7 +26,7 @@ def __generate_response(maps_data, yaml):
                     value = ', '.join(map_value)
 
                 # Escape bad yaml values
-                value = value.replace('\n', '\\n').replace('\t', '\\t')
+                value = value.replace('\r', '\\r').replace('\n', '\\n').replace('\t', '\\t')
                 yaml_response += '\t{0}: {1}\n'.format(map_key, value)
         response = StreamingHttpResponse(yaml_response, content_type="text/plain")
     else:
@@ -63,7 +62,7 @@ def __map_info_from_objects(request, map_objects, yaml):
             categories = json.loads(map_object.categories)
             category_ids = [cat_id.strip('_') for cat_id in categories]
             category_objects = MapCategories.objects.filter(id__in=category_ids)
-            category_list = [html.escape(c.category_name) for c in category_objects]
+            category_list = [c.category_name for c in category_objects]
 
         minimap_path = os.path.join(
             settings.BASE_DIR, 'openra', 'data', 'maps',
@@ -78,21 +77,22 @@ def __map_info_from_objects(request, map_objects, yaml):
         download_url = 'http://' + request.META['HTTP_HOST'] + \
                        '/maps/' + str(map_object.id) + '/oramap'
 
+        # TODO: Title and author have ' replaced with '' before insertion into the database. Work out why and fix it
         results[map_object.map_hash] = {
             'id': map_object.id,
-            'title': html.escape(map_object.title),
-            'description': html.escape(map_object.description),
-            'info': html.escape(map_object.info),
-            'author': html.escape(map_object.author),
-            'map_type': html.escape(map_object.map_type),
+            'title': map_object.title.replace("''", "'"),
+            'description': map_object.description,
+            'info': map_object.info,
+            'author': map_object.author.replace("''", "'"),
+            'map_type': map_object.map_type,
             'players': map_object.players,
-            'game_mod': html.escape(map_object.game_mod),
+            'game_mod': map_object.game_mod,
             'map_hash': map_object.map_hash,
             'width': map_object.width,
             'height': map_object.height,
             'bounds': map_object.bounds,
             'spawnpoints': map_object.spawnpoints,
-            'tileset': html.escape(map_object.tileset),
+            'tileset': map_object.tileset,
             'revision': map_object.revision,
             'last_revision': last_revision,
             'requires_upgrade': map_object.requires_upgrade,

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -12,6 +12,9 @@ from django.contrib.auth.models import User
 from openra.models import Maps, Lints, Screenshots
 from openra import utility, misc
 
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
 # pylint: disable=too-many-return-statements
 # pylint: disable=too-many-locals
 # pylint: disable=broad-except
@@ -19,6 +22,7 @@ from openra import utility, misc
 class InvalidMapException(Exception):
     """Failed to parse or process an OpenRA map file"""
     def __init__(self, message):
+        super().__init__()
         self.message = message
 
 

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -52,17 +52,24 @@ def add_map_revision(oramap_path, user,
     if int(metadata['mapformat']) < 10:
         raise InvalidMapException('Unable to import maps older than map format 10.')
 
-    # Parse custom rules
-    rules_retcode, custom_rules = utility.run_utility_command(parser, game_mod, [
-        '--map-rules', oramap_path])
+    # Only attempt to parse rules for the default mods
+    # This will be fixed properly once we move to mod-based parsing
+    is_known_mod = metadata['game_mod'] in ['ra', 'cnc', 'd2k', 'ts']
 
-    if rules_retcode != 0:
-        misc.send_email_to_admin_OnMapFail(oramap_path)
-        raise InvalidMapException('Failed to parse custom rules.')
+    if is_known_mod:
+        rules_retcode, custom_rules = utility.run_utility_command(parser, metadata['game_mod'], [
+            '--map-rules', oramap_path])
 
-    # TODO: Check against the game's Ruleset.DefinesUnsafeCustomRules code instead of line count
-    advanced = len(custom_rules.split("\n")) > 8
-    base64_rules = base64.b64encode(custom_rules.encode()).decode()
+        if rules_retcode != 0:
+            misc.send_email_to_admin_OnMapFail(oramap_path)
+            raise InvalidMapException('Failed to parse custom rules.')
+
+        # TODO: Check against the game's Ruleset.DefinesUnsafeCustomRules code instead of line count
+        advanced = len(custom_rules.split("\n")) > 8
+        base64_rules = base64.b64encode(custom_rules.encode()).decode()
+    else:
+        base64_rules = ''
+        advanced = False
 
     expect_metadata_keys = [
         'title', 'author', 'categories', 'players', 'game_mod',
@@ -89,7 +96,7 @@ def add_map_revision(oramap_path, user,
         user=user,
         info=info,
         downloading=True,
-        requires_upgrade=True,
+        requires_upgrade=not is_known_mod,
         advanced_map=advanced,
         policy_cc=policy_options['cc'],
         policy_commercial=policy_options['commercial'],
@@ -124,26 +131,26 @@ def add_map_revision(oramap_path, user,
         except Exception:
             pass
 
-    # Run lint tests
-    print('Running --check-yaml')
-    lint_retcode, lint_output = utility.run_utility_command(parser, item.game_mod, [
-        '--check-yaml',
-        item_map_path
-    ])
+    if is_known_mod:
+        print('Running --check-yaml')
+        lint_retcode, lint_output = utility.run_utility_command(parser, item.game_mod, [
+            '--check-yaml',
+            item_map_path
+        ])
 
-    if lint_output:
-        Lints(
-            item_type='maps',
-            map_id=item.id,
-            version_tag=parser,
-            pass_status=lint_retcode == 0,
-            lint_output=lint_output,
-            posted=timezone.now(),
-        ).save()
+        if lint_output:
+            Lints(
+                item_type='maps',
+                map_id=item.id,
+                version_tag=parser,
+                pass_status=lint_retcode == 0,
+                lint_output=lint_output,
+                posted=timezone.now(),
+            ).save()
 
-    if lint_retcode == 0:
-        item.requires_upgrade = False
-        item.save()
+        if lint_retcode == 0:
+            item.requires_upgrade = False
+            item.save()
 
     print("--- New revision: %s" % item.id)
     return item

--- a/openra/utility.py
+++ b/openra/utility.py
@@ -42,6 +42,7 @@ def run_utility_command(parser, game_mod, args, cwd=None):
 
 def parse_map_metadata(oramap_path):
     # TODO: Replace this DIY parsing with a utility command that returns JSON
+    # TODO: Will need a migration to remove the quote-doubling from title and author
     metadata = {
         'mapformat': 0,
         'lua': False,


### PR DESCRIPTION
* "Failed to parse custom rules" for maps in non-ra mods
* API escaping problems

Also prevents the linter running on custom mods where we know it will fail, and squashes some extra pylint warnings.