### PR TITLE
Fix more regressions from recent upload pr

### DIFF
--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -39,12 +39,12 @@ def add_map_revision(oramap_path, user,
         '--map-hash', oramap_path])
 
     if hash_retcode != 0 or not map_hash:
-        raise InvalidMapException('Hash calculation failed')
+        raise InvalidMapException('Hash calculation failed.')
 
-    # Check if user has already uploaded the same map
-    # TODO: Why do we prevent this for the same user, but not others?
-    if Maps.objects.filter(user_id=user.id, map_hash=map_hash).exists():
-        raise InvalidMapException("You've already uploaded this map.")
+    # Require unique map hashes - allowing maps to have multiple RC entries
+    # makes it difficult to return consistent data through the map API
+    if Maps.objects.filter(map_hash=map_hash).exists():
+        raise InvalidMapException("Map has already been uploaded.")
 
     # Parse metadata
     print('Parsing map.yaml metadata')

--- a/openra/utility.py
+++ b/openra/utility.py
@@ -96,7 +96,7 @@ def parse_map_metadata(oramap_path):
             in_spawn_node = False
 
         if in_players_node:
-            players_nodes += '\t' * indent + line.strip() + '\n'
+            players_nodes += '\t' * (indent - 1) + line.strip() + '\n'
 
         split_index = line.find(':')
         if split_index < 0:


### PR DESCRIPTION
Fixes https://forum.openra.net/viewtopic.php?f=83&t=20830.

Fixes #349 by blocking duplicate hashes for any uploader: this is important because the primary API for querying maps is to use the map's hash, and if there are duplicates (one map with two sets of resource-center metadata) then we run into a problem with deciding which set to show.