### PR TITLE
Switch backend engines to AppImages.

### DIFF
--- a/openra/misc.py
+++ b/openra/misc.py
@@ -1,9 +1,6 @@
 import os
-import shutil
 import datetime
-import time
 import pytz
-import copy
 from functools import reduce
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
@@ -43,12 +40,6 @@ def selectLicenceInfo(itemObject):
         name = "Attribution-NonCommercial-ShareAlike 4.0 International"
         icons = 'by-nc-sa'
     return name, icons
-
-
-def addSlash(path):
-    if not path.endswith('/'):
-        path += '/'
-    return path
 
 
 def send_email_contacts_form(name, email, message):
@@ -259,33 +250,6 @@ def all_revisions_for_map(item_id):
         pass
 
 
-def Log(data, channel="default"):
-    log_path = os.path.join(settings.BASE_DIR, "logs")
-    if not os.path.isdir(log_path):
-        os.makedirs(log_path)
-    logfile = open(os.path.join(log_path, channel + ".log"), "a")
-    if data:
-        today = datetime.datetime.today()
-        timestamp = today.strftime('%Y/%m/%d %H:%M:%S') + ' [' + time.tzname[0] + ']:  '
-
-        logfile.write(timestamp + data.strip() + "\n")
-    logfile.close()
-    return True
-
-
-def copytree(src, dst, symlinks=False, ignore=None):
-    if not os.path.exists(dst):
-        os.makedirs(dst)
-    for item in os.listdir(src):
-        s = os.path.join(src, item)
-        d = os.path.join(dst, item)
-        if os.path.isdir(s):
-            copytree(s, d, symlinks, ignore)
-        else:
-            if not os.path.exists(d) or os.stat(s).st_mtime - os.stat(d).st_mtime > 1:
-                shutil.copy2(s, d)
-
-
 def map_filter(request, mapObject):
 
     selected_filter = {}
@@ -467,13 +431,6 @@ def user_account_age(user):
         return 0
 
     return (timezone.now() - user.date_joined).total_seconds() / 3600
-
-def build_utility_command(parser, game_mod, args):
-    game_mod = game_mod.lower()
-    if game_mod not in ['ra', 'cnc', 'd2k', 'ts']:
-        game_mod = 'ra'
-
-    return 'mono --debug %s %s %s' % (os.path.join(settings.OPENRA_ROOT_PATH, parser, 'OpenRA.Utility.exe'), game_mod, ' '.join(args))
 
 def first_oramap_in_directory(path):
     """Returns the first matching .oramap filename in a given path or None

--- a/openra/utility.py
+++ b/openra/utility.py
@@ -28,9 +28,8 @@ def run_utility_command(parser, game_mod, args, cwd=None):
     if game_mod not in ['ra', 'cnc', 'd2k', 'ts']:
         game_mod = 'ra'
 
-    popen = Popen(['mono', '--debug',
-                   os.path.join(settings.OPENRA_ROOT_PATH, parser, 'OpenRA.Utility.exe'),
-                   game_mod] + args, stdout=PIPE, cwd=cwd)
+    popen = Popen([os.path.join(settings.OPENRA_ROOT_PATH, parser, game_mod + '.AppImage'), '--utility'] + args,
+                  stdout=PIPE, cwd=cwd)
 
     output = b''
     for chunk in popen.stdout:

--- a/openra/views.py
+++ b/openra/views.py
@@ -420,23 +420,18 @@ def displayMap(request, arg):
 
             return HttpResponseRedirect('/maps/' + arg + '/')
 
-    disk_size = 0
     path = os.path.join(settings.BASE_DIR, __name__.split('.')[0], 'data', 'maps', arg)
-    try:
-        mapDir = os.listdir(path)
-        for filename in mapDir:
-            if filename.endswith(".oramap"):
-                disk_size = os.path.getsize(os.path.join(path, filename))
-                disk_size = misc.sizeof_fmt(disk_size)
-                break
-        mapDir = os.listdir(os.path.join(path, 'content'))
-    except FileNotFoundError as ex:
-        print(ex)
+    oramap_filename = misc.first_oramap_in_directory(path)
+    if not oramap_filename:
         return HttpResponseRedirect('/')
+
     try:
         mapObject = Maps.objects.get(id=arg)
     except:
         return HttpResponseRedirect('/')
+
+    disk_size = os.path.getsize(os.path.join(path, oramap_filename))
+    disk_size = misc.sizeof_fmt(disk_size)
 
     lints = []
     lintObject = Lints.objects.filter(map_id=mapObject.id, item_type='maps')

--- a/openra/views.py
+++ b/openra/views.py
@@ -497,9 +497,6 @@ def displayMap(request, arg):
     if mapObject.next_rev != 0:
         show_upgrade_map_button = False  # upgrade only the latest revision
 
-    if mapObject.parser not in settings.OPENRA_VERSIONS:
-        show_upgrade_map_button = False  # map was not parsed with a compatible version
-
     if not any([mapObject.parser in v for v in settings.OPENRA_UPDATE_VERSIONS.values()]):
         show_upgrade_map_button = False  # no compatible update targets
 
@@ -559,9 +556,6 @@ def updateMap(request, arg):
 
     if source_map.next_rev != 0:
         return HttpResponseRedirect('/maps/' + arg + '/')  # update only the latest revision
-
-    if source_map.parser not in settings.OPENRA_VERSIONS:
-        return HttpResponseRedirect('/maps/' + arg + '/')  # map was not parsed with a compatible parser
 
     update_parsers = [k for k in settings.OPENRA_UPDATE_VERSIONS if source_map.parser in settings.OPENRA_UPDATE_VERSIONS[k]]
     if not update_parsers:


### PR DESCRIPTION
This PR switches the engine backend from locally compiled builds to self-contained AppImages for the default mods.

This is not a proper implementation of #326, instead just implementing the minimum viable hack needed to support the upcoming official release. The current implementation forces us to drop parsers for anything before `playtest-20190106`, which was the first release to include the `--utility` AppImage flag. We will need to work around this when we get around to the big legacy-version map cleanup.

This also includes a couple of minor code cleanups and restores the map update logs that were accidentally broken by #350.