### PR TITLE
Switch backend engines to AppImages.

### DIFF
--- a/openra/settings.py.example
+++ b/openra/settings.py.example
@@ -166,9 +166,23 @@ ACCOUNT_ACTIVATION_DAYS = 7
 # Path to directory where OpenRA versions are stored
 OPENRA_ROOT_PATH = ''
 
-# OpenRA versions matching their directory names
+# OpenRA Versions matching their directory names
 # Reverse chronological order - newer versions must be listed first!
 OPENRA_VERSIONS = [
+    'playtest-20191021',
+    'release-20190314',
+    'release-20180923',
+    'release-20180307',
+    'release-20180218',
+    'release-20171014',
+]
+
+# Versions that should be run using the legacy mono environment
+# Versions not in this list will be treated as an extracted AppImage bundle
+OPENRA_LEGACY_VERSIONS = [
+    'release-20190314',
+    'playtest-20190106',
+    'release-20180923',
     'release-20180307',
     'release-20180218',
     'release-20171014',
@@ -176,7 +190,8 @@ OPENRA_VERSIONS = [
 
 # List of versions that each version can update from
 OPENRA_UPDATE_VERSIONS = {
-    'playtest-20180825': ['release-20180307', 'release-20171014']
+    'playtest-20191021': ['release-20190314', 'release-20181215', 'release-20180923', 'release-20180307', 'release-20171014'],
+    'release-20190314': ['playtest-20190106', 'release-20180923', 'release-20180307', 'release-20180218', 'release-20171014'],
 }
 
 # Email address (FROM) in our custom mail methods

--- a/openra/templates/uploadMap.html
+++ b/openra/templates/uploadMap.html
@@ -11,7 +11,7 @@
 
 			$('.upload-map-form-parser option:first-child').attr("selected", "selected");
 
-			$('.upload-map-form-parser option:first-child').append(' (the latest published)')
+			$('.upload-map-form-parser option:first-child').append(' (latest version)')
 		});
 	</script>
 

--- a/openra/utility.py
+++ b/openra/utility.py
@@ -28,8 +28,11 @@ def run_utility_command(parser, game_mod, args, cwd=None):
     if game_mod not in ['ra', 'cnc', 'd2k', 'ts']:
         game_mod = 'ra'
 
-    popen = Popen([os.path.join(settings.OPENRA_ROOT_PATH, parser, game_mod + '.AppImage'), '--utility'] + args,
-                  stdout=PIPE, cwd=cwd)
+    utility_args = [os.path.join(settings.OPENRA_ROOT_PATH, parser, game_mod, 'AppRun'), '--utility']
+    if parser in settings.OPENRA_LEGACY_VERSIONS:
+        utility_args = ['mono', '--debug', os.path.join(settings.OPENRA_ROOT_PATH, parser, 'OpenRA.Utility.exe'), game_mod]
+
+    popen = Popen(utility_args + args, stdout=PIPE, cwd=cwd)
 
     output = b''
     for chunk in popen.stdout:


### PR DESCRIPTION
Part 2 of #355. This restores support for legacy engine versions, and switches to unpacked AppImages.