### PR TITLE
Adjust margin-right in map_data_label fixing #358

### DIFF
--- a/openra/static/style003.css
+++ b/openra/static/style003.css
@@ -1259,6 +1259,7 @@ p.registerInfo {
 			color: #eee;
 			text-align: left;
 			padding: 0 0 1px;
+			margin-right: 0.2rem;
 			vertical-align: top;
 			font-size: 0.9em;
 		}


### PR DESCRIPTION
On Firefox, the classes map_data_label and map_data_text were otherwise
stuck together in the "map details" box, e.g. "Downloading: allowed".

See #358 for screenshot.
