### PR TITLE
Updates to allow for testing seeder without writing to data folder

### DIFF
--- a/openra/__init__.py
+++ b/openra/__init__.py
@@ -1,0 +1,5 @@
+from .containers import ServiceContainer
+from . import settings
+
+container = ServiceContainer()
+container.config.from_dict(settings.__dict__)

--- a/openra/__init__.py
+++ b/openra/__init__.py
@@ -1,5 +1,7 @@
-from .containers import ServiceContainer
+from .containers import Container
 from . import settings
 
-container = ServiceContainer()
+container = Container()
 container.config.from_dict(settings.__dict__)
+
+default_app_config = 'openra.apps.OpenraConfig'

--- a/openra/apps.py
+++ b/openra/apps.py
@@ -1,0 +1,14 @@
+"""Application config module."""
+
+from django.apps import AppConfig
+
+from openra import container
+
+class OpenraConfig(AppConfig):
+    name = "openra"
+
+    def ready(self):
+        container.wire(modules=[
+            ".handlers",
+            ".tests.test_commands",
+        ])

--- a/openra/containers.py
+++ b/openra/containers.py
@@ -1,0 +1,13 @@
+from dependency_injector import containers, providers
+from fs.memoryfs import MemoryFS
+from fs.osfs import OSFS
+from openra import settings
+from os import path
+
+class ServiceContainer(containers.DeclarativeContainer):
+    config = providers.Configuration()
+
+    fs = providers.Singleton(
+        OSFS,
+        path.join(settings.BASE_DIR, 'openra', 'data')
+    )

--- a/openra/containers.py
+++ b/openra/containers.py
@@ -4,10 +4,10 @@ from fs.osfs import OSFS
 from openra import settings
 from os import path
 
-class ServiceContainer(containers.DeclarativeContainer):
+class Container(containers.DeclarativeContainer):
     config = providers.Configuration()
 
-    fs = providers.Singleton(
+    dataFs = providers.Singleton(
         OSFS,
         path.join(settings.BASE_DIR, 'openra', 'data')
     )

--- a/openra/containers.py
+++ b/openra/containers.py
@@ -1,5 +1,4 @@
 from dependency_injector import containers, providers
-from fs.memoryfs import MemoryFS
 from fs.osfs import OSFS
 from openra import settings
 from os import path
@@ -7,7 +6,7 @@ from os import path
 class Container(containers.DeclarativeContainer):
     config = providers.Configuration()
 
-    dataFs = providers.Singleton(
+    data_fs = providers.Singleton(
         OSFS,
         path.join(settings.BASE_DIR, 'openra', 'data')
     )

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -2,10 +2,11 @@ import base64
 import tempfile
 import shutil
 import os
-import fs
 from subprocess import Popen, PIPE
 from fs.zipfs import ZipFS
 from fs.base import FS
+from fs import copy
+
 
 from django.conf import settings
 from django.utils import timezone
@@ -35,7 +36,7 @@ def add_map_revision(oramap_path, user,
                      parser, game_mod,
                      info, policy_options, posted_date,
                      revision=1, previous_revision_id=0,
-                     data_fs:FS=Provide[Container.dataFs]):
+                     data_fs:FS=Provide[Container.data_fs]):
     """ Parse and save a given oramap into the database.
         The input file is not modified, and must be cleaned up afterwards by the caller.
         Returns a Maps model or raises an InvalidMapException on error
@@ -128,12 +129,12 @@ def add_map_revision(oramap_path, user,
     if not data_fs.exists(item_content_path):
         data_fs.makedirs(item_content_path)
 
-    fs.copy.copy_file('/', oramap_path, data_fs, item_map_path)
+    copy.copy_file('/', oramap_path, data_fs, item_map_path)
 
     # Extract the oramap contents
     # TODO: Why do we need this?
     try:
-        fs.copy.copy_dir(ZipFS(oramap_path), '/', data_fs, item_content_path)
+        copy.copy_dir(ZipFS(oramap_path), '/', data_fs, item_content_path)
     except:
         pass
 

--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -129,7 +129,10 @@ def add_map_revision(oramap_path, user,
 
     # Extract the oramap contents
     # TODO: Why do we need this?
-    fs.copy.copy_dir(ZipFS(oramap_path), '/', data_fs, item_content_path)
+    try:
+        fs.copy.copy_dir(ZipFS(oramap_path), '/', data_fs, item_content_path)
+    except:
+        pass
 
     if previous_revision_id:
         previous_item = Maps.objects.get(id=previous_revision_id)

--- a/openra/tests/test_commands.py
+++ b/openra/tests/test_commands.py
@@ -10,6 +10,7 @@ from openra.models import User, Maps
 from dependency_injector import providers
 from openra import container
 from fs.memoryfs import MemoryFS
+from os import path
 
 class TestCommandSeedTestData(TestCase):
 
@@ -20,6 +21,18 @@ class TestCommandSeedTestData(TestCase):
         container.fs = providers.Singleton(
             MemoryFS
         )
+
+    def oramapFileExistsForMapId(self, mapId):
+        fs = container.fs()
+        filePath = path.join('maps', str(mapId))
+        if not fs.exists(filePath):
+            return False
+
+        for file in fs.scandir(filePath):
+            if file.suffix == '.oramap':
+                return True
+
+        return False
 
     def test_it_creates_a_super_user_with_the_details_provided(self):
         self.mockFileSystem()
@@ -53,6 +66,8 @@ class TestCommandSeedTestData(TestCase):
 
     def test_it_imports_the_sample_maps(self):
         self.mockFileSystem()
+
+        self.assertFalse(self.oramapFileExistsForMapId(1))
         self.runSeeder()
 
         maps = Maps.objects.filter()
@@ -66,6 +81,8 @@ class TestCommandSeedTestData(TestCase):
             standardMap.author
         )
 
+        self.assertTrue(self.oramapFileExistsForMapId(standardMap.id))
+
         yamlMap = maps[1]
 
         self.assertIsNotNone(yamlMap)
@@ -74,6 +91,8 @@ class TestCommandSeedTestData(TestCase):
             'Sample YAML Map',
             yamlMap.author
         )
+
+        self.assertTrue(self.oramapFileExistsForMapId(yamlMap.id))
 
         luaMap = maps[2]
 
@@ -84,4 +103,4 @@ class TestCommandSeedTestData(TestCase):
             luaMap.author
         )
 
-
+        self.assertTrue(self.oramapFileExistsForMapId(luaMap.id))

--- a/openra/tests/test_commands.py
+++ b/openra/tests/test_commands.py
@@ -17,29 +17,29 @@ from os import path
 
 class TestCommandSeedTestData(TestCase):
 
-    def runSeeder(self):
+    def run_seeder(self):
         call_command('seedtestdata', 'sampleuser@example.com', 'sampleuser', 'pass123')
 
-    def mockFileSystem(self):
-        container.dataFs.override(providers.Singleton(
+    def mock_file_system(self):
+        container.data_fs.override(providers.Singleton(
             MemoryFS
         ))
 
     @inject
-    def oramapFileExistsForMapId(self, mapId, dataFs:FS=Provide[Container.dataFs]):
-        filePath = path.join('maps', str(mapId))
-        if not dataFs.exists(filePath):
+    def oramap_file_exists_for_map_id(self, map_id, data_fs:FS=Provide[Container.data_fs]):
+        file_path = path.join('maps', str(map_id))
+        if not data_fs.exists(file_path):
             return False
 
-        for file in dataFs.scandir(filePath):
+        for file in data_fs.scandir(file_path):
             if file.suffix == '.oramap':
                 return True
 
         return False
 
     def test_it_creates_a_super_user_with_the_details_provided(self):
-        self.mockFileSystem()
-        self.runSeeder()
+        self.mock_file_system()
+        self.run_seeder()
 
         user = User.objects.first()
 
@@ -68,42 +68,42 @@ class TestCommandSeedTestData(TestCase):
         )
 
     def test_it_imports_the_sample_maps(self):
-        self.mockFileSystem()
+        self.mock_file_system()
 
-        self.assertFalse(self.oramapFileExistsForMapId(1))
-        self.runSeeder()
+        self.assertFalse(self.oramap_file_exists_for_map_id(1))
+        self.run_seeder()
 
         maps = Maps.objects.filter()
 
-        standardMap = maps[0]
+        standard_map = maps[0]
 
-        self.assertIsNotNone(standardMap)
+        self.assertIsNotNone(standard_map)
 
         self.assertEquals(
             'Sample Author',
-            standardMap.author
+            standard_map.author
         )
 
-        self.assertTrue(self.oramapFileExistsForMapId(standardMap.id))
+        self.assertTrue(self.oramap_file_exists_for_map_id(standard_map.id))
 
-        yamlMap = maps[1]
+        yaml_map = maps[1]
 
-        self.assertIsNotNone(yamlMap)
+        self.assertIsNotNone(yaml_map)
 
         self.assertEquals(
             'Sample YAML Map',
-            yamlMap.author
+            yaml_map.author
         )
 
-        self.assertTrue(self.oramapFileExistsForMapId(yamlMap.id))
+        self.assertTrue(self.oramap_file_exists_for_map_id(yaml_map.id))
 
-        luaMap = maps[2]
+        lua_map = maps[2]
 
-        self.assertIsNotNone(luaMap)
+        self.assertIsNotNone(lua_map)
 
         self.assertEquals(
             'Sample Lua Author',
-            luaMap.author
+            lua_map.author
         )
 
-        self.assertTrue(self.oramapFileExistsForMapId(luaMap.id))
+        self.assertTrue(self.oramap_file_exists_for_map_id(lua_map.id))

--- a/openra/tests/test_commands.py
+++ b/openra/tests/test_commands.py
@@ -8,8 +8,11 @@ from django.contrib.auth import authenticate
 
 from openra.models import User, Maps
 from dependency_injector import providers
+from dependency_injector.wiring import inject, Provide
 from openra import container
+from openra.containers import Container
 from fs.memoryfs import MemoryFS
+from fs.base import FS
 from os import path
 
 class TestCommandSeedTestData(TestCase):
@@ -18,17 +21,17 @@ class TestCommandSeedTestData(TestCase):
         call_command('seedtestdata', 'sampleuser@example.com', 'sampleuser', 'pass123')
 
     def mockFileSystem(self):
-        container.fs = providers.Singleton(
+        container.dataFs.override(providers.Singleton(
             MemoryFS
-        )
+        ))
 
-    def oramapFileExistsForMapId(self, mapId):
-        fs = container.fs()
+    @inject
+    def oramapFileExistsForMapId(self, mapId, dataFs:FS=Provide[Container.dataFs]):
         filePath = path.join('maps', str(mapId))
-        if not fs.exists(filePath):
+        if not dataFs.exists(filePath):
             return False
 
-        for file in fs.scandir(filePath):
+        for file in dataFs.scandir(filePath):
             if file.suffix == '.oramap':
                 return True
 

--- a/openra/tests/test_commands.py
+++ b/openra/tests/test_commands.py
@@ -7,19 +7,25 @@ from django.utils.six import StringIO
 from django.contrib.auth import authenticate
 
 from openra.models import User, Maps
+from dependency_injector import providers
+from openra import container
+from fs.memoryfs import MemoryFS
 
 class TestCommandSeedTestData(TestCase):
 
     def runSeeder(self):
         call_command('seedtestdata', 'sampleuser@example.com', 'sampleuser', 'pass123')
 
-    def getSeededUser(self):
-        return User.objects.first()
+    def mockFileSystem(self):
+        container.fs = providers.Singleton(
+            MemoryFS
+        )
 
     def test_it_creates_a_super_user_with_the_details_provided(self):
+        self.mockFileSystem()
         self.runSeeder()
 
-        user = self.getSeededUser()
+        user = User.objects.first()
 
         self.assertEqual(
             'sampleuser@example.com',
@@ -46,6 +52,7 @@ class TestCommandSeedTestData(TestCase):
         )
 
     def test_it_imports_the_sample_maps(self):
+        self.mockFileSystem()
         self.runSeeder()
 
         maps = Maps.objects.filter()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ psycopg2==2.8
 ptyprocess==0.5.1
 python3-openid==3.0.9
 pytz==2016.1
-PyYAML==3.11
-requests==2.9.1
+PyYAML==3.13
+requests==2.14.2
 requests-oauthlib==0.6.1
 simplegeneric==0.8.1
 traitlets==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ requests-oauthlib==0.6.1
 simplegeneric==0.8.1
 traitlets==4.1.0
 factory_boy==2.9.0
+dependency-injector==4.41.0
+fs==2.4.16


### PR DESCRIPTION
Adds the following:

**Dependency Injection:**

This package allows for making some defined modules and classes to be hot-swappable, which will aid with testing and upgrading, and also help make the code more modular.

It also allows for function arguments to be automatically pulled from its containers, but this doesn't work in python 3.5, so that will need to wait until python is updated.

*Edit:* As the server is now running python 3.7, I've change this now to inject the dependencies in the couple of places that the filesystem is used so far.

**FS:**

The FS module has several different implementations of a base FS structure, which makes it easy to swap out the OS file system for one in memory for testing for example. It also allows for Zips to be accessed and treated almost the same way as other parts of the file system so that may come in useful later.

**Updates to process_upload in handlers.php:**

I've swapped out some of the direct file system operations with some which use the FS module served from the service container. This allowed for the FS to be hot-swapped in the seeder test.

For now I've just manually tested it on the RC, but I'm hoping to break this code out into a more testable structure later.
