### PR TITLE
Initial docker integration

### DIFF
--- a/openra/apps.py
+++ b/openra/apps.py
@@ -11,4 +11,5 @@ class OpenraConfig(AppConfig):
         container.wire(modules=[
             ".handlers",
             ".tests.test_commands",
+            ".management.commands.testdocker",
         ])

--- a/openra/containers.py
+++ b/openra/containers.py
@@ -2,6 +2,9 @@ from dependency_injector import containers, providers
 from fs.osfs import OSFS
 from openra import settings
 from os import path
+import docker
+
+from openra.services.docker import Docker
 
 class Container(containers.DeclarativeContainer):
     config = providers.Configuration()
@@ -10,3 +13,11 @@ class Container(containers.DeclarativeContainer):
         OSFS,
         path.join(settings.BASE_DIR, 'openra', 'data')
     )
+
+    docker = providers.Singleton(
+        Docker,
+        providers.Callable(
+            docker.from_env
+        )
+    )
+

--- a/openra/management/commands/testdocker.py
+++ b/openra/management/commands/testdocker.py
@@ -1,4 +1,6 @@
+from dependency_injector.wiring import Provide, inject
 from django.core.management.base import BaseCommand, CommandError
+from openra.containers import Container
 from openra.services.docker import Docker
 
 class Command(BaseCommand):
@@ -8,4 +10,8 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args, **options):
-        print(Docker().test_docker())
+        self.test_docker()
+
+    @inject
+    def test_docker(self, docker:Docker=Provide[Container.docker]):
+        print(docker.test_docker())

--- a/openra/management/commands/testdocker.py
+++ b/openra/management/commands/testdocker.py
@@ -10,8 +10,8 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args, **options):
-        self.test_docker()
+        self._test_docker()
 
     @inject
-    def test_docker(self, docker:Docker=Provide[Container.docker]):
+    def _test_docker(self, docker:Docker=Provide[Container.docker]):
         print(docker.test_docker())

--- a/openra/management/commands/testdocker.py
+++ b/openra/management/commands/testdocker.py
@@ -8,4 +8,4 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args, **options):
-        print(Docker().testDocker())
+        print(Docker().test_docker())

--- a/openra/management/commands/testdocker.py
+++ b/openra/management/commands/testdocker.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand, CommandError
+from openra.services.docker import Docker
+
+class Command(BaseCommand):
+    help = 'Checks that docker is functioning as needed'
+
+    def add_arguments(self, parser):
+        pass
+
+    def handle(self, *args, **options):
+
+        print(Docker().testDocker())

--- a/openra/management/commands/testdocker.py
+++ b/openra/management/commands/testdocker.py
@@ -8,5 +8,4 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args, **options):
-
         print(Docker().testDocker())

--- a/openra/resources/docker/Dockerfile
+++ b/openra/resources/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu

--- a/openra/services/docker.py
+++ b/openra/services/docker.py
@@ -43,14 +43,9 @@ class Docker:
             working_dir='/build',
         )
 
-    def _get_client(self):
-        return self._client
-
     def _docker_run(self, command, volumes=[], working_dir='/'):
-        client = self._get_client()
-
-        return client.containers.run(
-            self._get_docker_image(client),
+        return self._client.containers.run(
+            self._get_docker_image(self._client),
             command,
             remove=True,
             volumes=volumes,

--- a/openra/services/docker.py
+++ b/openra/services/docker.py
@@ -1,0 +1,59 @@
+import docker
+
+from os import path
+
+
+class Docker:
+
+    def testDocker(self):
+        return self._dockerRun(
+            'echo "Docker appears to be running ok"',
+        )
+
+    def extractAppImage(self, appImagePath, toDir):
+        appImage = path.basename(appImagePath)
+
+        return self._dockerRun(
+            'bash -c "cp /in/{0} . && '
+                    './{0} --appimage-extract && '
+                    'rm {0}"'.format(appImage),
+            volumes=[
+                appImagePath+':/in/'+appImage,
+                toDir+':/out/squashfs-root'
+            ],
+            workingDir="/out",
+        )
+
+    def runUtilityCommand(self, enginePath, command, additionalVolumes=[]):
+        return self._dockerRun(
+            '/engine/AppRun --utility ' + command,
+            volumes=[
+                enginePath+':/engine',
+            ]+additionalVolumes,
+            workingDir="/build",
+        )
+
+    def _getClient(self):
+        return docker.from_env()
+
+    def _dockerRun(self, command, volumes=[], workingDir="/"):
+        client = self._getClient()
+
+        return client.containers.run(
+            self._getDockerImage(client),
+            command,
+            remove=True,
+            volumes=volumes,
+            working_dir=workingDir
+        ).decode('UTF-8')
+
+
+    def _getDockerImage(self, client):
+        imagePath = '/src/openra/resources/docker'
+
+        try:
+            return client.images.get('rc-ubuntu')
+        except:
+            return client.images.build(path=imagePath, tag="rc-ubuntu")[0]
+
+

--- a/openra/services/docker.py
+++ b/openra/services/docker.py
@@ -1,6 +1,7 @@
 import docker
 
 from os import path
+from django.conf import settings
 
 
 class Docker:
@@ -12,7 +13,6 @@ class Docker:
 
     def extractAppImage(self, appImagePath, toDir):
         appImage = path.basename(appImagePath)
-
         return self._dockerRun(
             'bash -c "cp /in/{0} . && '
                     './{0} --appimage-extract && '
@@ -49,7 +49,7 @@ class Docker:
 
 
     def _getDockerImage(self, client):
-        imagePath = '/src/openra/resources/docker'
+        imagePath = path.join(settings.BASE_DIR, 'openra', 'resources', 'docker')
 
         try:
             return client.images.get('rc-ubuntu')

--- a/openra/services/docker.py
+++ b/openra/services/docker.py
@@ -7,60 +7,59 @@ import re
 
 class Docker:
 
-    def testDocker(self):
-        return self._dockerRun(
+    def test_docker(self):
+        return self._docker_run(
             'echo "Docker appears to be running ok"',
         )
 
-    def extractAppImage(self, appImagePath, toDir):
-        pattern = re.compile("^[A-z0-9\-\/\.]+$")
-        if not pattern.match(appImagePath):
-            raise IncompatibleAppImagePathException('Incompatible character used in appimage path: ' + appImagePath)
+    def extract_app_image(self, app_image_path, to_dir):
+        pattern = re.compile('^[A-z0-9\-\/\.]+$')
+        if not pattern.match(app_image_path):
+            raise IncompatibleAppImagePathException('Incompatible character used in appimage path: ' + app_image_path)
 
-        appImage = path.basename(appImagePath)
-        return self._dockerRun(
+        return self._docker_run(
             'bash -c "cp /in/AppImage . && '
                     './AppImage --appimage-extract && '
                     'rm AppImage"',
             volumes=[
-                appImagePath+':/in/AppImage',
-                toDir+':/out/squashfs-root'
+                app_image_path+':/in/AppImage',
+                to_dir+':/out/squashfs-root'
             ],
-            workingDir="/out",
+            working_dir='/out',
         )
 
-    def runUtilityCommand(self, enginePath, command, additionalVolumes=[]):
-        return self._dockerRun(
+    def run_utility_command(self, engine_path, command, additional_volumes=[]):
+        return self._docker_run(
             '/engine/AppRun --utility ' + command,
             volumes=[
-                enginePath+':/engine',
-            ]+additionalVolumes,
-            workingDir="/build",
+                engine_path+':/engine',
+            ]+additional_volumes,
+            working_dir='/build',
         )
 
-    def _getClient(self):
+    def _get_client(self):
         return docker.from_env()
 
-    def _dockerRun(self, command, volumes=[], workingDir="/"):
-        client = self._getClient()
+    def _docker_run(self, command, volumes=[], working_dir='/'):
+        client = self._get_client()
 
         return client.containers.run(
-            self._getDockerImage(client),
+            self._get_docker_image(client),
             command,
             remove=True,
             volumes=volumes,
-            working_dir=workingDir
+            working_dir=working_dir
         ).decode('UTF-8')
 
 
-    def _getDockerImage(self, client):
-        imagePath = path.join(settings.BASE_DIR, 'openra', 'resources', 'docker')
+    def _get_docker_image(self, client):
+        image_path = path.join(settings.BASE_DIR, 'openra', 'resources', 'docker')
 
         try:
             return client.images.get(settings.DOCKER_IMAGE_TAG)
         except:
-            return client.images.build(path=imagePath, tag=settings.DOCKER_IMAGE_TAG)[0]
+            return client.images.build(path=image_path, tag=settings.DOCKER_IMAGE_TAG)[0]
 
 class IncompatibleAppImagePathException(Exception):
-    "Docker library only accepts basic characters, rename before extracting"
+    'Docker library only accepts basic characters, rename before extracting'
     pass

--- a/openra/services/docker.py
+++ b/openra/services/docker.py
@@ -3,9 +3,15 @@ import docker
 from os import path
 from django.conf import settings
 import re
+from docker.client import DockerClient
 
 
 class Docker:
+
+    _client: DockerClient
+
+    def __init__(self, client:DockerClient):
+        self._client = client
 
     def test_docker(self):
         return self._docker_run(
@@ -38,7 +44,7 @@ class Docker:
         )
 
     def _get_client(self):
-        return docker.from_env()
+        return self._client
 
     def _docker_run(self, command, volumes=[], working_dir='/'):
         client = self._get_client()

--- a/openra/settings.py.example
+++ b/openra/settings.py.example
@@ -218,3 +218,6 @@ SITE_MAINTENANCE_OVER = '00:00 GMT'  # when we finish technical works
 UTILITY_TIME_LIMIT = 60
 
 GOOGLE_RECAPTCHA_SECRET_KEY = "YOUR-PRIVATE-KEY"
+
+# This will appear on the image created by the resource center when you run "docker image list"
+DOCKER_IMAGE_TAG = 'resource-center'

--- a/openra/tests/test_commands.py
+++ b/openra/tests/test_commands.py
@@ -107,3 +107,10 @@ class TestCommandSeedTestData(TestCase):
         )
 
         self.assertTrue(self.oramap_file_exists_for_map_id(lua_map.id))
+
+class TestTestDocker(TestCase):
+
+    def test_it_runs_the_test_docker_command(self):
+        # Currently untestable but will be
+        # once service injection gets merged
+        pass

--- a/openra/tests/test_commands.py
+++ b/openra/tests/test_commands.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import MagicMock, Mock, patch
 
 from django.utils import timezone
 from django.test import TestCase
@@ -14,6 +15,8 @@ from openra.containers import Container
 from fs.memoryfs import MemoryFS
 from fs.base import FS
 from os import path
+
+from openra.services.docker import Docker
 
 class TestCommandSeedTestData(TestCase):
 
@@ -110,7 +113,15 @@ class TestCommandSeedTestData(TestCase):
 
 class TestTestDocker(TestCase):
 
-    def test_it_runs_the_test_docker_command(self):
-        # Currently untestable but will be
-        # once service injection gets merged
-        pass
+    @patch('builtins.print')
+    def test_it_runs_the_test_docker_command_and_prints_the_result(self, print_mock):
+        docker_mock = Mock(spec=Docker)
+        docker_mock.test_docker = MagicMock(
+            return_value = 'sample'
+        )
+        container.docker.override(docker_mock)
+
+        call_command('testdocker')
+
+        docker_mock.test_docker.assert_called_once_with()
+        print_mock.assert_called_once_with('sample')

--- a/openra/tests/test_service_docker.py
+++ b/openra/tests/test_service_docker.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 class TestServiceDocker(TestCase):
 
-    def test_test_docker_will_pass_the_correct_parameters(self):
+    def test_that_test_docker_will_pass_the_correct_parameters(self):
         client_mock = Mock()
         client_mock.containers = Mock()
         client_mock.images = Mock()

--- a/openra/tests/test_service_docker.py
+++ b/openra/tests/test_service_docker.py
@@ -10,29 +10,29 @@ from django.conf import settings
 class TestServiceDocker(TestCase):
 
     def test_test_docker_will_pass_the_correct_parameters(self):
-        clientMock = Mock()
-        clientMock.containers = Mock()
-        clientMock.images = Mock()
-        clientMock.images.get = MagicMock(
+        client_mock = Mock()
+        client_mock.containers = Mock()
+        client_mock.images = Mock()
+        client_mock.images.get = MagicMock(
             return_value ='fake_image'
         )
-        clientMock.containers.run = MagicMock(
+        client_mock.containers.run = MagicMock(
             return_value = b'mock_return'
         )
 
         docker = Docker()
 
-        docker._getClient = MagicMock(
-            return_value = clientMock
+        docker._get_client = MagicMock(
+            return_value = client_mock
         )
 
         self.assertEquals(
             'mock_return',
-            docker.testDocker()
+            docker.test_docker()
         )
 
-        clientMock.images.get.assert_called_once_with(settings.DOCKER_IMAGE_TAG)
-        clientMock.containers.run.assert_called_once_with(
+        client_mock.images.get.assert_called_once_with(settings.DOCKER_IMAGE_TAG)
+        client_mock.containers.run.assert_called_once_with(
             'fake_image',
             'echo "Docker appears to be running ok"',
             remove=True,
@@ -42,33 +42,33 @@ class TestServiceDocker(TestCase):
 
     def test_extract_app_image_will_pass_the_correct_parameters(self):
 
-        clientMock = Mock()
-        clientMock.containers = Mock()
-        clientMock.images = Mock()
-        clientMock.images.get = MagicMock(
+        client_mock = Mock()
+        client_mock.containers = Mock()
+        client_mock.images = Mock()
+        client_mock.images.get = MagicMock(
             return_value ='fake_image'
         )
-        clientMock.containers.run = MagicMock(
+        client_mock.containers.run = MagicMock(
             return_value = b'mock_return'
         )
 
         docker = Docker()
 
-        docker._getClient = MagicMock(
-            return_value = clientMock
+        docker._get_client = MagicMock(
+            return_value = client_mock
         )
 
         self.assertEquals(
             'mock_return',
-            docker.extractAppImage(
+            docker.extract_app_image(
                 '/sample/image.AppImage',
                 '/extract/to/location',
             )
         )
 
-        clientMock.images.get.assert_called_once_with(settings.DOCKER_IMAGE_TAG)
+        client_mock.images.get.assert_called_once_with(settings.DOCKER_IMAGE_TAG)
 
-        clientMock.containers.run.assert_called_once_with(
+        client_mock.containers.run.assert_called_once_with(
             'fake_image',
             'bash -c "cp /in/AppImage . && '
                     './AppImage --appimage-extract && '
@@ -82,45 +82,45 @@ class TestServiceDocker(TestCase):
         )
 
     def test_extract_app_image_will_throw_exception_if_an_incompatible_filename_is_used(self):
-        clientMock = Mock()
+        client_mock = Mock()
 
         docker = Docker()
 
-        docker._getClient = MagicMock(
-            return_value = clientMock
+        docker._get_client = MagicMock(
+            return_value = client_mock
         )
 
         self.assertRaises(
             IncompatibleAppImagePathException,
-            docker.extractAppImage,
-            '/sample/im age.AppImage',
+            docker.extract_app_image,
+            '/sample/im age.App_image',
             '/extract/to/location'
         )
 
     def test_run_utility_command_will_pass_the_correct_parameters(self):
 
-        clientMock = Mock()
-        clientMock.containers = Mock()
-        clientMock.images = Mock()
-        clientMock.images.get = MagicMock(
+        client_mock = Mock()
+        client_mock.containers = Mock()
+        client_mock.images = Mock()
+        client_mock.images.get = MagicMock(
             side_effect = Exception()
         )
-        clientMock.images.build = MagicMock(
+        client_mock.images.build = MagicMock(
             return_value=('fake_image', 'something_else')
         )
-        clientMock.containers.run = MagicMock(
+        client_mock.containers.run = MagicMock(
             return_value=b'mock_return'
         )
 
         docker = Docker()
 
-        docker._getClient = MagicMock(
-            return_value = clientMock
+        docker._get_client = MagicMock(
+            return_value = client_mock
         )
 
         self.assertEquals(
             'mock_return',
-            docker.runUtilityCommand(
+            docker.run_utility_command(
                 '/engine/path',
                 'sample_command',
                 [
@@ -129,13 +129,13 @@ class TestServiceDocker(TestCase):
             )
         )
 
-        clientMock.images.get.assert_called_once_with(settings.DOCKER_IMAGE_TAG)
+        client_mock.images.get.assert_called_once_with(settings.DOCKER_IMAGE_TAG)
 
-        imagePath = path.join(settings.BASE_DIR, 'openra', 'resources', 'docker')
+        image_path = path.join(settings.BASE_DIR, 'openra', 'resources', 'docker')
 
-        clientMock.images.build.assert_called_once_with(path=imagePath, tag=settings.DOCKER_IMAGE_TAG)
+        client_mock.images.build.assert_called_once_with(path=image_path, tag=settings.DOCKER_IMAGE_TAG)
 
-        clientMock.containers.run.assert_called_once_with(
+        client_mock.containers.run.assert_called_once_with(
             'fake_image',
             '/engine/AppRun --utility sample_command',
             remove=True,

--- a/openra/tests/test_service_docker.py
+++ b/openra/tests/test_service_docker.py
@@ -20,11 +20,7 @@ class TestServiceDocker(TestCase):
             return_value = b'mock_return'
         )
 
-        docker = Docker()
-
-        docker._get_client = MagicMock(
-            return_value = client_mock
-        )
+        docker = Docker(client_mock)
 
         self.assertEquals(
             'mock_return',
@@ -41,7 +37,6 @@ class TestServiceDocker(TestCase):
         )
 
     def test_extract_app_image_will_pass_the_correct_parameters(self):
-
         client_mock = Mock()
         client_mock.containers = Mock()
         client_mock.images = Mock()
@@ -52,11 +47,7 @@ class TestServiceDocker(TestCase):
             return_value = b'mock_return'
         )
 
-        docker = Docker()
-
-        docker._get_client = MagicMock(
-            return_value = client_mock
-        )
+        docker = Docker(client_mock)
 
         self.assertEquals(
             'mock_return',
@@ -84,11 +75,7 @@ class TestServiceDocker(TestCase):
     def test_extract_app_image_will_throw_exception_if_an_incompatible_filename_is_used(self):
         client_mock = Mock()
 
-        docker = Docker()
-
-        docker._get_client = MagicMock(
-            return_value = client_mock
-        )
+        docker = Docker(client_mock)
 
         self.assertRaises(
             IncompatibleAppImagePathException,
@@ -98,7 +85,6 @@ class TestServiceDocker(TestCase):
         )
 
     def test_run_utility_command_will_pass_the_correct_parameters(self):
-
         client_mock = Mock()
         client_mock.containers = Mock()
         client_mock.images = Mock()
@@ -112,11 +98,7 @@ class TestServiceDocker(TestCase):
             return_value=b'mock_return'
         )
 
-        docker = Docker()
-
-        docker._get_client = MagicMock(
-            return_value = client_mock
-        )
+        docker = Docker(client_mock)
 
         self.assertEquals(
             'mock_return',

--- a/openra/tests/test_service_docker.py
+++ b/openra/tests/test_service_docker.py
@@ -1,0 +1,128 @@
+import datetime
+
+from django.utils import timezone
+from unittest import TestCase
+from unittest.mock import  Mock, MagicMock
+from openra.services.docker import Docker
+
+class TestServiceDocker(TestCase):
+
+    def test_test_docker_will_pass_the_correct_parameters_to_docker_run(self):
+        clientMock = Mock()
+        clientMock.containers = Mock()
+        clientMock.images = Mock()
+        clientMock.images.get = MagicMock(
+            return_value ='fake_image'
+        )
+        clientMock.containers.run = MagicMock(
+            return_value = b'mock_return'
+        )
+
+        docker = Docker()
+
+        docker._getClient = MagicMock(
+            return_value = clientMock
+        )
+
+        self.assertEquals(
+            'mock_return',
+            docker.testDocker()
+        )
+
+        clientMock.images.get.assert_called_once_with('rc-ubuntu')
+        clientMock.containers.run.assert_called_once_with(
+            'fake_image',
+            'echo "Docker appears to be running ok"',
+            remove=True,
+            volumes=[],
+            working_dir='/',
+        )
+
+
+    def test_extract_app_image_will_pass_the_correct_parameters_to_docker_run(self):
+
+        clientMock = Mock()
+        clientMock.containers = Mock()
+        clientMock.images = Mock()
+        clientMock.images.get = MagicMock(
+            return_value ='fake_image'
+        )
+        clientMock.containers.run = MagicMock(
+            return_value = b'mock_return'
+        )
+
+        docker = Docker()
+
+        docker._getClient = MagicMock(
+            return_value = clientMock
+        )
+
+        self.assertEquals(
+            'mock_return',
+            docker.extractAppImage(
+                '/sample/image.AppImage',
+                '/extract/to/location',
+            )
+        )
+
+        clientMock.images.get.assert_called_once_with('rc-ubuntu')
+
+        clientMock.containers.run.assert_called_once_with(
+            'fake_image',
+            'bash -c "cp /in/image.AppImage . && '
+                    './image.AppImage --appimage-extract && '
+                    'rm image.AppImage"',
+            remove=True,
+            volumes=[
+                '/sample/image.AppImage:/in/image.AppImage',
+                '/extract/to/location:/out/squashfs-root'
+            ],
+            working_dir="/out",
+        )
+
+    def test_run_utility_command_will_pass_the_correct_parameters_to_docker_run(self):
+
+        clientMock = Mock()
+        clientMock.containers = Mock()
+        clientMock.images = Mock()
+        clientMock.images.get = MagicMock(
+            side_effect = Exception()
+        )
+        clientMock.images.build = MagicMock(
+            return_value=('fake_image', 'something_else')
+        )
+        clientMock.containers.run = MagicMock(
+            return_value=b'mock_return'
+        )
+
+        docker = Docker()
+
+        docker._getClient = MagicMock(
+            return_value = clientMock
+        )
+
+        self.assertEquals(
+            'mock_return',
+            docker.runUtilityCommand(
+                '/engine/path',
+                'sample_command',
+                [
+                    'src/icons:icons'
+                ]
+            )
+        )
+
+        clientMock.images.get.assert_called_once_with('rc-ubuntu')
+
+        clientMock.images.build.assert_called_once_with(path='/src/openra/resources/docker', tag='rc-ubuntu')
+
+        clientMock.containers.run.assert_called_once_with(
+            'fake_image',
+            '/engine/AppRun --utility sample_command',
+            remove=True,
+            volumes=[
+                '/engine/path:/engine',
+                'src/icons:icons'
+            ],
+            working_dir="/build",
+        )

--- a/openra/tests/test_service_docker.py
+++ b/openra/tests/test_service_docker.py
@@ -4,6 +4,8 @@ from django.utils import timezone
 from unittest import TestCase
 from unittest.mock import  Mock, MagicMock
 from openra.services.docker import Docker
+from os import path
+from django.conf import settings
 
 class TestServiceDocker(TestCase):
 
@@ -114,7 +116,9 @@ class TestServiceDocker(TestCase):
 
         clientMock.images.get.assert_called_once_with('rc-ubuntu')
 
-        clientMock.images.build.assert_called_once_with(path='/src/openra/resources/docker', tag='rc-ubuntu')
+        imagePath = path.join(settings.BASE_DIR, 'openra', 'resources', 'docker')
+
+        clientMock.images.build.assert_called_once_with(path=imagePath, tag='rc-ubuntu')
 
         clientMock.containers.run.assert_called_once_with(
             'fake_image',

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ traitlets==4.1.0
 factory_boy==2.9.0
 dependency-injector==4.41.0
 fs==2.4.16
+docker==4.4.4


### PR DESCRIPTION
Adds a Docker service to RC, along with tests.

I haven't integrated this at all into the code yet though as that will be much easier when the PR below gets merged, as that adds a service container:

https://github.com/OpenRA/OpenRA-Resources/pull/385

It consists of a Docker class which can carry out the operations needed by the RC in docker, and an additional manage.py command that can be run on the host machine to make sure it's able to access docker ok:

`python3 manage.py testdocker`