### PR TITLE
Added initial GitHub service for locating official AppImages

### DIFF
--- a/openra/containers.py
+++ b/openra/containers.py
@@ -3,8 +3,9 @@ from fs.osfs import OSFS
 from openra import settings
 from os import path
 import docker
-
 from openra.services.docker import Docker
+from github import Github as GithubClient
+from openra.services.github import Github
 
 class Container(containers.DeclarativeContainer):
     config = providers.Configuration()
@@ -21,3 +22,10 @@ class Container(containers.DeclarativeContainer):
         )
     )
 
+    github = providers.Singleton(
+        Github,
+        providers.Callable(
+            GithubClient,
+            settings.GITHUB_API_KEY
+        )
+    )

--- a/openra/services/github.py
+++ b/openra/services/github.py
@@ -1,0 +1,44 @@
+from github import Github as GithubClient
+from openra import settings
+
+class Github():
+
+    def listReleases(self):
+        repo = self._getRepo()
+#
+        releases = repo.get_releases()
+
+        output = []
+
+        for release in releases:
+            output.append({
+                "tag":release.tag_name,
+                "published":release.published_at,
+            })
+
+        return output
+
+    def getReleaseAssets(self, tag):
+        repo = self._getRepo()
+#
+        release = repo.get_release(tag)
+
+        assets = release.get_assets()
+        output = []
+
+        for asset in assets:
+            output.append({
+                "name":asset.name,
+                "url":asset.browser_download_url,
+            })
+
+        return output
+
+    def _getClient(self):
+        return GithubClient(settings.GITHUB_API_KEY)
+
+    def _getRepo(self):
+        github = self._getClient()
+
+        return github.get_repo(settings.GITHUB_OPENRA_REPO, lazy=True)
+

--- a/openra/services/github.py
+++ b/openra/services/github.py
@@ -1,15 +1,22 @@
+from dependency_injector.wiring import Provide, inject
 from github import Github as GithubClient
 from openra import settings
 
 class Github():
+
+    _client: GithubClient
+    _repo = None
+
+    def __init__(self, client:GithubClient):
+        self._client = client
 
     def list_releases(self):
         releases = []
 
         for release in self._get_repo().get_releases():
             releases.append({
-                "tag":release.tag_name,
-                "published":release.published_at,
+                "tag": release.tag_name,
+                "published": release.published_at,
             })
 
         return releases
@@ -19,22 +26,15 @@ class Github():
 
         for asset in self._get_repo().get_release(tag).get_assets():
             assets.append({
-                "name":asset.name,
-                "url":asset.browser_download_url,
+                "name": asset.name,
+                "url": asset.browser_download_url,
             })
 
         return assets
 
-    _repo = None
-
-    def _get_client(self):
-        return GithubClient(settings.GITHUB_API_KEY)
-
     def _get_repo(self):
         if self._repo == None:
-            github = self._get_client()
-
-            self._repo = github.get_repo(settings.GITHUB_OPENRA_REPO, lazy=True)
+            self._repo = self._client.get_repo(settings.GITHUB_OPENRA_REPO, lazy=True)
 
         return self._repo
 

--- a/openra/services/github.py
+++ b/openra/services/github.py
@@ -3,10 +3,10 @@ from openra import settings
 
 class Github():
 
-    def listReleases(self):
+    def list_releases(self):
         releases = []
 
-        for release in self._getRepo().get_releases():
+        for release in self._get_repo().get_releases():
             releases.append({
                 "tag":release.tag_name,
                 "published":release.published_at,
@@ -14,10 +14,10 @@ class Github():
 
         return releases
 
-    def getReleaseAssets(self, tag):
+    def get_release_assets(self, tag):
         assets = []
 
-        for asset in self._getRepo().get_release(tag).get_assets():
+        for asset in self._get_repo().get_release(tag).get_assets():
             assets.append({
                 "name":asset.name,
                 "url":asset.browser_download_url,
@@ -27,12 +27,12 @@ class Github():
 
     _repo = None
 
-    def _getClient(self):
+    def _get_client(self):
         return GithubClient(settings.GITHUB_API_KEY)
 
-    def _getRepo(self):
+    def _get_repo(self):
         if self._repo == None:
-            github = self._getClient()
+            github = self._get_client()
 
             self._repo = github.get_repo(settings.GITHUB_OPENRA_REPO, lazy=True)
 

--- a/openra/services/github.py
+++ b/openra/services/github.py
@@ -4,41 +4,37 @@ from openra import settings
 class Github():
 
     def listReleases(self):
-        repo = self._getRepo()
-#
-        releases = repo.get_releases()
+        releases = []
 
-        output = []
-
-        for release in releases:
-            output.append({
+        for release in self._getRepo().get_releases():
+            releases.append({
                 "tag":release.tag_name,
                 "published":release.published_at,
             })
 
-        return output
+        return releases
 
     def getReleaseAssets(self, tag):
-        repo = self._getRepo()
-#
-        release = repo.get_release(tag)
+        assets = []
 
-        assets = release.get_assets()
-        output = []
-
-        for asset in assets:
-            output.append({
+        for asset in self._getRepo().get_release(tag).get_assets():
+            assets.append({
                 "name":asset.name,
                 "url":asset.browser_download_url,
             })
 
-        return output
+        return assets
+
+    _repo = None
 
     def _getClient(self):
         return GithubClient(settings.GITHUB_API_KEY)
 
     def _getRepo(self):
-        github = self._getClient()
+        if self._repo == None:
+            github = self._getClient()
 
-        return github.get_repo(settings.GITHUB_OPENRA_REPO, lazy=True)
+            self._repo = github.get_repo(settings.GITHUB_OPENRA_REPO, lazy=True)
+
+        return self._repo
 

--- a/openra/settings.py.example
+++ b/openra/settings.py.example
@@ -221,3 +221,9 @@ GOOGLE_RECAPTCHA_SECRET_KEY = "YOUR-PRIVATE-KEY"
 
 # This will appear on the image created by the resource center when you run "docker image list"
 DOCKER_IMAGE_TAG = 'resource-center'
+
+# Not likely to ever change
+GITHUB_OPENRA_REPO = "OpenRA/OpenRA"
+
+# Not necessarily required but reduces rate limiting
+GITHUB_API_KEY = None

--- a/openra/tests/test_service_github.py
+++ b/openra/tests/test_service_github.py
@@ -1,0 +1,83 @@
+import datetime
+
+from django.utils import timezone
+from unittest import TestCase
+from unittest.mock import  Mock, MagicMock, PropertyMock
+from os import path
+from django.conf import settings
+from openra.services.github import Github
+
+class TestServiceGithub(TestCase):
+
+    def test_will_obtain_release_data_from_github(self):
+        publishedDate = datetime.datetime
+
+        repoMock = Mock()
+        repoMock.get_releases = MagicMock(
+            return_value = [
+                Mock(tag_name="sample1", published_at=publishedDate),
+                Mock(tag_name="sample2", published_at=publishedDate)
+            ]
+        )
+
+        clientMock = Mock()
+        clientMock.get_repo = MagicMock(
+            return_value = repoMock
+        )
+
+        github = Github()
+
+        github._getClient = MagicMock(
+            return_value = clientMock
+        )
+
+        self.assertEquals([{
+                "tag":"sample1",
+                "published":publishedDate,
+            },{
+                "tag":"sample2",
+                "published":publishedDate,
+            }],
+            github.listReleases()
+        )
+
+    def test_will_return_assets_for_a_release(self):
+        releaseMock = Mock()
+
+        mockAsset1 = Mock(browser_download_url="url1")
+        mockAsset1.configure_mock(name="asset1")
+        mockAsset2 = Mock(browser_download_url="url2")
+        mockAsset2.configure_mock(name="asset2")
+
+        releaseMock.get_assets = MagicMock(
+            return_value = [
+                mockAsset1,
+                mockAsset2,
+            ]
+        )
+
+        repoMock = Mock()
+        repoMock.get_release = MagicMock(
+            return_value = releaseMock
+        )
+
+        clientMock = Mock()
+        clientMock.get_repo = MagicMock(
+            return_value = repoMock
+        )
+
+        github = Github()
+
+        github._getClient = MagicMock(
+            return_value = clientMock
+        )
+
+        self.assertEquals([{
+                "name":"asset1",
+                "url":"url1",
+            },{
+                "name":"asset2",
+                "url":"url2",
+            }],
+            github.getReleaseAssets('release_tag')
+        )

--- a/openra/tests/test_service_github.py
+++ b/openra/tests/test_service_github.py
@@ -1,9 +1,7 @@
 import datetime
 
-from django.utils import timezone
 from unittest import TestCase
-from unittest.mock import  Mock, MagicMock, PropertyMock
-from os import path
+from unittest.mock import  Mock, MagicMock
 from django.conf import settings
 from openra.services.github import Github
 
@@ -39,6 +37,13 @@ class TestServiceGithub(TestCase):
                 "published":publishedDate,
             }],
             github.listReleases()
+        )
+
+        repoMock.get_releases.assert_called_once_with()
+
+        clientMock.get_repo.assert_called_once_with(
+            settings.GITHUB_OPENRA_REPO,
+            lazy=True
         )
 
     def test_will_return_assets_for_a_release(self):
@@ -80,4 +85,15 @@ class TestServiceGithub(TestCase):
                 "url":"url2",
             }],
             github.getReleaseAssets('release_tag')
+        )
+
+        releaseMock.get_assets.assert_called_once_with()
+
+        repoMock.get_release.assert_called_once_with(
+            'release_tag'
+        )
+
+        clientMock.get_repo.assert_called_once_with(
+            settings.GITHUB_OPENRA_REPO,
+            lazy=True
         )

--- a/openra/tests/test_service_github.py
+++ b/openra/tests/test_service_github.py
@@ -23,18 +23,14 @@ class TestServiceGithub(TestCase):
             return_value = repo_mock
         )
 
-        github = Github()
-
-        github._get_client = MagicMock(
-            return_value = client_mock
-        )
+        github = Github(client_mock)
 
         self.assertEquals([{
-                "tag":"sample1",
-                "published":published_date,
+                "tag": "sample1",
+                "published": published_date,
             },{
-                "tag":"sample2",
-                "published":published_date,
+                "tag": "sample2",
+                "published": published_date,
             }],
             github.list_releases()
         )
@@ -71,18 +67,14 @@ class TestServiceGithub(TestCase):
             return_value = repo_mock
         )
 
-        github = Github()
-
-        github._get_client = MagicMock(
-            return_value = client_mock
-        )
+        github = Github(client_mock)
 
         self.assertEquals([{
-                "name":"asset1",
-                "url":"url1",
+                "name": "asset1",
+                "url": "url1",
             },{
-                "name":"asset2",
-                "url":"url2",
+                "name": "asset2",
+                "url": "url2",
             }],
             github.get_release_assets('release_tag')
         )
@@ -115,11 +107,7 @@ class TestServiceGithub(TestCase):
             return_value = repo_mock
         )
 
-        github = Github()
-
-        github._get_client = MagicMock(
-            return_value = client_mock
-        )
+        github = Github(client_mock)
 
         github.list_releases()
         github.get_release_assets('sample')

--- a/openra/tests/test_service_github.py
+++ b/openra/tests/test_service_github.py
@@ -97,3 +97,34 @@ class TestServiceGithub(TestCase):
             settings.GITHUB_OPENRA_REPO,
             lazy=True
         )
+
+    def test_will_only_get_the_repo_once_over_multiple_calls(self):
+        releaseMock = Mock()
+        releaseMock.get_assets = MagicMock(
+            return_value = []
+        )
+        repoMock = Mock()
+        repoMock.get_releases = MagicMock(
+            return_value = []
+        )
+        repoMock.get_release = MagicMock(
+            return_value = releaseMock
+        )
+        clientMock = Mock()
+        clientMock.get_repo = MagicMock(
+            return_value = repoMock
+        )
+
+        github = Github()
+
+        github._getClient = MagicMock(
+            return_value = clientMock
+        )
+
+        github.listReleases()
+        github.getReleaseAssets('sample')
+
+        clientMock.get_repo.assert_called_once()
+        repoMock.get_releases.assert_called_once()
+        repoMock.get_release.assert_called_once()
+        releaseMock.get_assets.assert_called_once()

--- a/openra/tests/test_service_github.py
+++ b/openra/tests/test_service_github.py
@@ -8,73 +8,73 @@ from openra.services.github import Github
 class TestServiceGithub(TestCase):
 
     def test_will_obtain_release_data_from_github(self):
-        publishedDate = datetime.datetime
+        published_date = datetime.datetime
 
-        repoMock = Mock()
-        repoMock.get_releases = MagicMock(
+        repo_mock = Mock()
+        repo_mock.get_releases = MagicMock(
             return_value = [
-                Mock(tag_name="sample1", published_at=publishedDate),
-                Mock(tag_name="sample2", published_at=publishedDate)
+                Mock(tag_name="sample1", published_at=published_date),
+                Mock(tag_name="sample2", published_at=published_date)
             ]
         )
 
-        clientMock = Mock()
-        clientMock.get_repo = MagicMock(
-            return_value = repoMock
+        client_mock = Mock()
+        client_mock.get_repo = MagicMock(
+            return_value = repo_mock
         )
 
         github = Github()
 
-        github._getClient = MagicMock(
-            return_value = clientMock
+        github._get_client = MagicMock(
+            return_value = client_mock
         )
 
         self.assertEquals([{
                 "tag":"sample1",
-                "published":publishedDate,
+                "published":published_date,
             },{
                 "tag":"sample2",
-                "published":publishedDate,
+                "published":published_date,
             }],
-            github.listReleases()
+            github.list_releases()
         )
 
-        repoMock.get_releases.assert_called_once_with()
+        repo_mock.get_releases.assert_called_once_with()
 
-        clientMock.get_repo.assert_called_once_with(
+        client_mock.get_repo.assert_called_once_with(
             settings.GITHUB_OPENRA_REPO,
             lazy=True
         )
 
     def test_will_return_assets_for_a_release(self):
-        releaseMock = Mock()
+        release_mock = Mock()
 
-        mockAsset1 = Mock(browser_download_url="url1")
-        mockAsset1.configure_mock(name="asset1")
-        mockAsset2 = Mock(browser_download_url="url2")
-        mockAsset2.configure_mock(name="asset2")
+        mock_asset1 = Mock(browser_download_url="url1")
+        mock_asset1.configure_mock(name="asset1")
+        mock_asset2 = Mock(browser_download_url="url2")
+        mock_asset2.configure_mock(name="asset2")
 
-        releaseMock.get_assets = MagicMock(
+        release_mock.get_assets = MagicMock(
             return_value = [
-                mockAsset1,
-                mockAsset2,
+                mock_asset1,
+                mock_asset2,
             ]
         )
 
-        repoMock = Mock()
-        repoMock.get_release = MagicMock(
-            return_value = releaseMock
+        repo_mock = Mock()
+        repo_mock.get_release = MagicMock(
+            return_value = release_mock
         )
 
-        clientMock = Mock()
-        clientMock.get_repo = MagicMock(
-            return_value = repoMock
+        client_mock = Mock()
+        client_mock.get_repo = MagicMock(
+            return_value = repo_mock
         )
 
         github = Github()
 
-        github._getClient = MagicMock(
-            return_value = clientMock
+        github._get_client = MagicMock(
+            return_value = client_mock
         )
 
         self.assertEquals([{
@@ -84,47 +84,47 @@ class TestServiceGithub(TestCase):
                 "name":"asset2",
                 "url":"url2",
             }],
-            github.getReleaseAssets('release_tag')
+            github.get_release_assets('release_tag')
         )
 
-        releaseMock.get_assets.assert_called_once_with()
+        release_mock.get_assets.assert_called_once_with()
 
-        repoMock.get_release.assert_called_once_with(
+        repo_mock.get_release.assert_called_once_with(
             'release_tag'
         )
 
-        clientMock.get_repo.assert_called_once_with(
+        client_mock.get_repo.assert_called_once_with(
             settings.GITHUB_OPENRA_REPO,
             lazy=True
         )
 
     def test_will_only_get_the_repo_once_over_multiple_calls(self):
-        releaseMock = Mock()
-        releaseMock.get_assets = MagicMock(
+        release_mock = Mock()
+        release_mock.get_assets = MagicMock(
             return_value = []
         )
-        repoMock = Mock()
-        repoMock.get_releases = MagicMock(
+        repo_mock = Mock()
+        repo_mock.get_releases = MagicMock(
             return_value = []
         )
-        repoMock.get_release = MagicMock(
-            return_value = releaseMock
+        repo_mock.get_release = MagicMock(
+            return_value = release_mock
         )
-        clientMock = Mock()
-        clientMock.get_repo = MagicMock(
-            return_value = repoMock
+        client_mock = Mock()
+        client_mock.get_repo = MagicMock(
+            return_value = repo_mock
         )
 
         github = Github()
 
-        github._getClient = MagicMock(
-            return_value = clientMock
+        github._get_client = MagicMock(
+            return_value = client_mock
         )
 
-        github.listReleases()
-        github.getReleaseAssets('sample')
+        github.list_releases()
+        github.get_release_assets('sample')
 
-        clientMock.get_repo.assert_called_once()
-        repoMock.get_releases.assert_called_once()
-        repoMock.get_release.assert_called_once()
-        releaseMock.get_assets.assert_called_once()
+        client_mock.get_repo.assert_called_once()
+        repo_mock.get_releases.assert_called_once()
+        repo_mock.get_release.assert_called_once()
+        release_mock.get_assets.assert_called_once()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ factory_boy==2.9.0
 dependency-injector==4.41.0
 fs==2.4.16
 docker==4.4.4
+PyGithub==1.56
+urllib3==1.26.13


### PR DESCRIPTION
Adds a basic service to connect to github and get a list of releases, and then to get a list of assets for a release.

It uses a python module that it a bit API-request heavy so if that ends up being a problem, it might be worth switching to something else. As this will likely only be needed infrequently though, it shouldn't be a problem.

I think it might be better to filter the assets and pull the app image files themselves outside of this module as that sounds like code that could get reused in a different way later.