### PR TITLE
Fixed issue where lint check couldn't find the map file

### DIFF
--- a/openra/handlers.py
+++ b/openra/handlers.py
@@ -147,7 +147,7 @@ def add_map_revision(oramap_path, user,
         print('Running --check-yaml')
         lint_retcode, lint_output = utility.run_utility_command(parser, item.game_mod, [
             '--check-yaml',
-            item_map_path
+            oramap_path
         ])
 
         if lint_output:


### PR DESCRIPTION
The map file path was determined based on several other paths, and due to the FS update it is no longer guaranteed that there is a map path in FS at that time.

For now I've switched it out to use the temp path, where the map has been uploaded to. In the future this will be done more cleanly.