### PR TITLE
Added tests for panel maps page and removed some redundant code

### DIFF
--- a/openra/content.py
+++ b/openra/content.py
@@ -12,5 +12,5 @@ titles = {
     # TODO reformat like others
     'feed': 'OpenRA Resource Center - RSS Feed',
     'search': 'Search',
-
+    'panel': 'My Maps',
 }

--- a/openra/templates/control_panel.html
+++ b/openra/templates/control_panel.html
@@ -1,70 +1,70 @@
 {% load customTags %}
 <div id="panel_content">
-    {% if amount_maps != 0 %}
-        <div id="map_grid">
-            {% for item in maps %}
-            <div class="map_grid_cell">
-                <a href="/maps/{{item.id}}/">
-                    <div class="cell-link-container">
-                        <div><img src="/maps/{{item.id}}/minimap" /></div><div class="link_title">{{ item.title|strip_tags }}</div>
-                    </div>
-                    {% if item.downloading == False or item.amount_reports >= 3 %}
-                    <div class="map-custom-status"><img src="/static/images/attention-mini.jpg" /></div>
-                    {% endif %}
-                    {% if item.advanced_map %}
-                    <div class="map-custom-status"><img src="/static/images/advanced-mini.jpg" /></div>
-                    {% endif %}
-                    {% if item.lua %}
-                    <div class="map-custom-status"><img src="/static/images/lua-mini.jpg" /></div>
-                    {% endif %}
-                </a>
-                <div class="map_tooltip">
-                    <div class="map_tooltip_mod mod_{{ item.game_mod }}">{{ item.game_mod|upper }}</div>
-                    <table>
-                        <tr>
-                            <td class="tooltip_title">Author: </td>
-                            <td class="tooltip_value">{{ item.author|strip_tags }} </td>
-                        </tr>
-                    </table>
-                    <table>
-                        <tr>
-                            <td class="tooltip_title_misc">Revision: </td>
-                            <td class="tooltip_value_misc">{{ item.revision }}</td>
-                            <td class="tooltip_title_misc">Players: </td>
-                            <td class="tooltip_value_misc">{{ item.players }}</td>
-                        </tr>
-                        <tr>
-                            <td class="tooltip_title_misc">Comments: </td>
-                            <td class="tooltip_value_misc">{{ comments|amount_comments:item.id }}</td>
-                            <td class="tooltip_title_misc">Rating: </td>
-                            <td class="tooltip_value_misc">{{ item.rating }}</td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-        <div class="clear"></div>
-        {% if 2 in range %}
-            <div id="paging">
-                {% for i in range %}
-                <div class="paging_cell">
-                    {% if i <= 3 or i >= range|length|add:"-2" or i < page|add:"3" and i > page|add:"-3" or i == 4 and page == 7 or i == range|length|add:"-3" and page == range|length|add:"-6" %}
-                    {% if page == i %}
-                    <span>{{ i }}</span>
-                    {% else %}
-                    <a href="/panel/page/{{i}}/">{{ i }}</a>
-                    {% endif %}
-                    {% else %}
-                    {% if i < page %}
-                    <span class='no-page-before hide_block'>...</span>
-                    {% else %}
-                    <span class='no-page-after hide_block'>...</span>
-                    {% endif %}
-                    {% endif %}
-                </div>
-                {% endfor %}
-            </div>
-        {% endif %}
-    {% endif %}
+	{% if amount_maps != 0 %}
+		<div id="map_grid">
+			{% for item in maps %}
+			<div class="map_grid_cell">
+				<a href="/maps/{{item.id}}/">
+					<div class="cell-link-container">
+						<div><img src="/maps/{{item.id}}/minimap" /></div><div class="link_title">{{ item.title|strip_tags }}</div>
+					</div>
+					{% if item.downloading == False or item.amount_reports >= 3 %}
+					<div class="map-custom-status"><img src="/static/images/attention-mini.jpg" /></div>
+					{% endif %}
+					{% if item.advanced_map %}
+					<div class="map-custom-status"><img src="/static/images/advanced-mini.jpg" /></div>
+					{% endif %}
+					{% if item.lua %}
+					<div class="map-custom-status"><img src="/static/images/lua-mini.jpg" /></div>
+					{% endif %}
+				</a>
+				<div class="map_tooltip">
+					<div class="map_tooltip_mod mod_{{ item.game_mod }}">{{ item.game_mod|upper }}</div>
+					<table>
+						<tr>
+							<td class="tooltip_title">Author: </td>
+							<td class="tooltip_value">{{ item.author|strip_tags }} </td>
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td class="tooltip_title_misc">Revision: </td>
+							<td class="tooltip_value_misc">{{ item.revision }}</td>
+							<td class="tooltip_title_misc">Players: </td>
+							<td class="tooltip_value_misc">{{ item.players }}</td>
+						</tr>
+						<tr>
+							<td class="tooltip_title_misc">Comments: </td>
+							<td class="tooltip_value_misc">{{ comments|amount_comments:item.id }}</td>
+							<td class="tooltip_title_misc">Rating: </td>
+							<td class="tooltip_value_misc">{{ item.rating }}</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+			{% endfor %}
+		</div>
+		<div class="clear"></div>
+		{% if 2 in range %}
+			<div id="paging">
+				{% for i in range %}
+				<div class="paging_cell">
+					{% if i <= 3 or i >= range|length|add:"-2" or i < page|add:"3" and i > page|add:"-3" or i == 4 and page == 7 or i == range|length|add:"-3" and page == range|length|add:"-6" %}
+					{% if page == i %}
+					<span>{{ i }}</span>
+					{% else %}
+					<a href="/panel/page/{{i}}/">{{ i }}</a>
+					{% endif %}
+					{% else %}
+					{% if i < page %}
+					<span class='no-page-before hide_block'>...</span>
+					{% else %}
+					<span class='no-page-after hide_block'>...</span>
+					{% endif %}
+					{% endif %}
+				</div>
+				{% endfor %}
+			</div>
+		{% endif %}
+	{% endif %}
 </div>

--- a/openra/templates/control_panel.html
+++ b/openra/templates/control_panel.html
@@ -1,81 +1,70 @@
 {% load customTags %}
 <div id="panel_content">
-	<nav class="side_nav">
-		<ul>
-			<li><a href="/panel/mymaps/" {% if '/panel/mymaps/' in request.path %}{{'class="nav-selected"'}}{% endif %}>My Maps ({{ amount_maps }})</a></li>
-			<li><a style="opacity: 0.5;" href="#" {% if '/panel/myscreenshots/' == request.path %}{{'class="nav-selected"'}}{% endif %}>My Screenshots (0)</a></li>
-		</ul>
-	</nav>
-
-	<div class="side_nav_content">
-	{% if '/panel/mymaps/' in request.path %}
-		{% if amount_maps != 0 %}
-		<div id="map_grid">
-		{% for item in maps %}
-			<div class="map_grid_cell">
-				<a href="/maps/{{item.id}}/">
-					<div class="cell-link-container">
-						<div><img src="/maps/{{item.id}}/minimap" /></div><div class="link_title">{{ item.title|strip_tags }}</div>
-					</div>
-					{% if item.downloading == False or item.amount_reports >= 3 %}
-					<div class="map-custom-status"><img src="/static/images/attention-mini.jpg" /></div>
-					{% endif %}
-					{% if item.advanced_map %}
-					<div class="map-custom-status"><img src="/static/images/advanced-mini.jpg" /></div>
-					{% endif %}
-					{% if item.lua %}
-					<div class="map-custom-status"><img src="/static/images/lua-mini.jpg" /></div>
-					{% endif %}
-				</a>
-				<div class="map_tooltip">
-					<div class="map_tooltip_mod mod_{{ item.game_mod }}">{{ item.game_mod|upper }}</div>
-					<table>
-						<tr>
-							<td class="tooltip_title">Author: </td>
-							<td class="tooltip_value">{{ item.author|strip_tags }} </td>
-						</tr>
-					</table>
-					<table>
-						<tr>
-							<td class="tooltip_title_misc">Revision: </td>
-							<td class="tooltip_value_misc">{{ item.revision }}</td>
-							<td class="tooltip_title_misc">Players: </td>
-							<td class="tooltip_value_misc">{{ item.players }}</td>
-						</tr>
-						<tr>
-							<td class="tooltip_title_misc">Comments: </td>
-							<td class="tooltip_value_misc">{{ comments|amount_comments:item.id }}</td>
-							<td class="tooltip_title_misc">Rating: </td>
-							<td class="tooltip_value_misc">{{ item.rating }}</td>
-						</tr>
-					</table>
-				</div>
-			</div>
-		{% endfor %}
-		</div>
-		<div class="clear"></div>
-		{% if 2 in range %}
-		<div id="paging">
-		{% for i in range %}
-			<div class="paging_cell">
-			{% if i <= 3 or i >= range|length|add:"-2" or i < page|add:"3" and i > page|add:"-3" or i == 4 and page == 7 or i == range|length|add:"-3" and page == range|length|add:"-6" %}
-				{% if page == i %}
-					<span>{{ i }}</span>
-				{% else %}
-					<a href="/panel/mymaps/page/{{i}}">{{ i }}</a>
-				{% endif %}
-			{% else %}
-				{% if i < page %}
-					<span class='no-page-before hide_block'>...</span>
-				{% else %}
-					<span class='no-page-after hide_block'>...</span>
-				{% endif %}
-			{% endif %}
-			</div>
-		{% endfor %}
-	</div>
-		{% endif %}
-		{% endif %}
-	{% endif %}
-	</div>
+    {% if amount_maps != 0 %}
+        <div id="map_grid">
+            {% for item in maps %}
+            <div class="map_grid_cell">
+                <a href="/maps/{{item.id}}/">
+                    <div class="cell-link-container">
+                        <div><img src="/maps/{{item.id}}/minimap" /></div><div class="link_title">{{ item.title|strip_tags }}</div>
+                    </div>
+                    {% if item.downloading == False or item.amount_reports >= 3 %}
+                    <div class="map-custom-status"><img src="/static/images/attention-mini.jpg" /></div>
+                    {% endif %}
+                    {% if item.advanced_map %}
+                    <div class="map-custom-status"><img src="/static/images/advanced-mini.jpg" /></div>
+                    {% endif %}
+                    {% if item.lua %}
+                    <div class="map-custom-status"><img src="/static/images/lua-mini.jpg" /></div>
+                    {% endif %}
+                </a>
+                <div class="map_tooltip">
+                    <div class="map_tooltip_mod mod_{{ item.game_mod }}">{{ item.game_mod|upper }}</div>
+                    <table>
+                        <tr>
+                            <td class="tooltip_title">Author: </td>
+                            <td class="tooltip_value">{{ item.author|strip_tags }} </td>
+                        </tr>
+                    </table>
+                    <table>
+                        <tr>
+                            <td class="tooltip_title_misc">Revision: </td>
+                            <td class="tooltip_value_misc">{{ item.revision }}</td>
+                            <td class="tooltip_title_misc">Players: </td>
+                            <td class="tooltip_value_misc">{{ item.players }}</td>
+                        </tr>
+                        <tr>
+                            <td class="tooltip_title_misc">Comments: </td>
+                            <td class="tooltip_value_misc">{{ comments|amount_comments:item.id }}</td>
+                            <td class="tooltip_title_misc">Rating: </td>
+                            <td class="tooltip_value_misc">{{ item.rating }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        <div class="clear"></div>
+        {% if 2 in range %}
+            <div id="paging">
+                {% for i in range %}
+                <div class="paging_cell">
+                    {% if i <= 3 or i >= range|length|add:"-2" or i < page|add:"3" and i > page|add:"-3" or i == 4 and page == 7 or i == range|length|add:"-3" and page == range|length|add:"-6" %}
+                    {% if page == i %}
+                    <span>{{ i }}</span>
+                    {% else %}
+                    <a href="/panel/page/{{i}}/">{{ i }}</a>
+                    {% endif %}
+                    {% else %}
+                    {% if i < page %}
+                    <span class='no-page-before hide_block'>...</span>
+                    {% else %}
+                    <span class='no-page-after hide_block'>...</span>
+                    {% endif %}
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endif %}
 </div>

--- a/openra/templates/header.html
+++ b/openra/templates/header.html
@@ -76,7 +76,7 @@
 			<li><a href="/"><span {% if request.path == '/' %}{{ 'class="nav-selected"' }}{% endif %}>Home</span></a></li>
 			<li><a href="/maps/"><span {% if '/maps' in request.path %}{{ 'class="nav-selected"' }}{% endif %}>Maps</span></a></li>
 		{% if user.is_authenticated %}
-			<li><a href="/panel/"><span {% if '/panel' in request.path %}{{ 'class="nav-selected"' }}{% endif %}>My Content</span></a></li>
+			<li><a href="/panel/"><span {% if '/panel' in request.path %}{{ 'class="nav-selected"' }}{% endif %}>My Maps</span></a></li>
 			<li><a href="/upload/map/"><span {% if '/upload/map' in request.path %}{{ 'class="nav-selected"' }}{% endif %}>Upload Map</span></a></li>
 		{% else %}
 			<li><a href="/login/"><span {% if request.path == '/login/' %}{{ 'class="nav-selected"' }}{% endif %}>Sign In</span></a></li>

--- a/openra/tests/routes/test_route_base.py
+++ b/openra/tests/routes/test_route_base.py
@@ -9,38 +9,44 @@ class TestRouteBase(TestCase):
     _route: str
     _client: Client
 
-    def _get(self, client, data):
+    def _get(self, client, data, route):
         self._client = client
-        return client.get(self._route, data)
+        return client.get(
+            route if route else self._route,
+            data
+        )
 
-    def get(self, data={}):
-        return self._get(Client(), data)
+    def get(self, data={}, route=None):
+        return self._get(Client(), data, route)
 
-    def get_authed(self, data={}):
+    def get_authed(self, data={}, user=None, route=None):
         client = Client()
         client.force_login(
-            UserFactory()
+            user if user else UserFactory()
         )
-        return self._get(client, data)
+        return self._get(client, data, route)
 
-    def _post(self, client, data):
+    def _post(self, client, data, route):
         self._client = client
-        return self._client.post(self._route, data)
+        return client.post(
+            route if route else self._route,
+            data
+        )
 
-    def post(self, data={}):
-        return self._post(Client(), data)
+    def post(self, data={}, route=None):
+        return self._post(Client(), data, route)
 
-    def post_authed(self, data={}):
+    def post_authed(self, data={}, user=None, route=None):
         client = Client()
         client.force_login(
-            UserFactory()
+            user if user else UserFactory()
         )
-        return self._post(client, data)
+        return self._post(client, data, route)
 
     def assert_contains(self, response, contents=[],
-                        status_code=200,
-                        title=''
-                        ):
+            status_code=200,
+            title=''
+        ):
         if title != '':
             contents.append(f'<title>OpenRA Resource Center - {title}</title>')
         for content in contents:
@@ -48,6 +54,16 @@ class TestRouteBase(TestCase):
                 response,
                 content,
                 status_code=status_code
+            )
+
+        return response
+
+    def assert_doesnt_contain(self, response, contents=[]):
+        decoded_response = response.content.decode('utf-8')
+        for content in contents:
+            self.assertNotIn(
+                content,
+                decoded_response
             )
 
         return response

--- a/openra/tests/routes/test_route_control_panel.py
+++ b/openra/tests/routes/test_route_control_panel.py
@@ -1,0 +1,178 @@
+from datetime import timedelta
+from django.contrib import auth
+from django.contrib.auth.base_user import make_password
+from django.test import override_settings
+from django.utils import timezone
+from openra import content
+from openra.helpers import merge_dicts
+from openra.tests.factories import MapsFactory, UserFactory
+
+from openra.tests.routes.test_route_base import TestRouteBase
+
+
+class TestRouteControlPanel(TestRouteBase):
+
+    _route = '/panel/'
+
+    def test_route_can_be_accessed_by_an_authed_user(self):
+        self.assert_contains(
+            self.get_authed(),
+            [
+                'Sign out',
+                'My Maps'
+            ],
+            title=content.titles['panel']
+        )
+
+    @override_settings(SITE_MAINTENANCE=True)
+    def test_route_shows_maintenance_page(self):
+        self.assert_is_maintenance(
+            self.get()
+        )
+
+    def test_route_redirects_to_login_if_not_authed(self):
+        response = self.get()
+
+        self.assertEquals(
+            302,
+            response.status_code
+        )
+
+        self.assertEquals(
+            '/login/',
+            response.url
+        )
+
+    def test_route_will_show_a_users_maps(self):
+        user = UserFactory()
+        user.save()
+        map = MapsFactory(
+            user = user
+        )
+        map.save()
+
+        map2 = MapsFactory(
+            title = 'different_title'
+        )
+        map2.save()
+
+        view = self.get_authed(
+            user=user
+        )
+
+        self.assert_contains(
+            view,
+            [
+                map.title,
+                map.game_mod,
+                map.author,
+            ]
+        )
+
+        self.assert_doesnt_contain(
+            view,
+            [
+                map2.title,
+            ]
+        )
+
+    def test_route_will_show_16_user_maps(self):
+        user = UserFactory()
+        user.save()
+        shown = []
+        for i in range(20):
+            map = MapsFactory(
+                user = user,
+                posted = timezone.now(),
+                title = "map_title_" + str(i) + "_"
+            )
+            map.save()
+            shown.append(map)
+
+        not_shown = []
+        for i in range(20, 22):
+            map = MapsFactory(
+                user = user,
+                posted = timezone.now() - timedelta(hours=1),
+                title = "map_title_" + str(i) + "_"
+            )
+            map.save()
+            not_shown.append(map)
+
+        view = self.get_authed(
+            user=user
+        )
+
+        self.assert_contains(
+            view,
+            [
+                '/panel/page/2/'
+            ]
+        )
+
+        for map in shown:
+            self.assert_contains(
+                view,
+                [
+                    map.title,
+                ]
+            )
+
+        for map in not_shown:
+            self.assert_doesnt_contain(
+                view,
+                [
+                    map.title,
+                ]
+            )
+
+    def test_route_can_show_later_pages(self):
+        user = UserFactory()
+        user.save()
+        not_shown = []
+        for i in range(20):
+            map = MapsFactory(
+                user = user,
+                posted = timezone.now(),
+                title = "map_title_" + str(i) + "_"
+            )
+            map.save()
+            not_shown.append(map)
+
+        shown = []
+        for i in range(20, 22):
+            map = MapsFactory(
+                user = user,
+                posted = timezone.now() - timedelta(hours=1),
+                title = "map_title_" + str(i) + "_"
+            )
+            map.save()
+            shown.append(map)
+
+        view = self.get_authed(
+            route='/panel/page/2/',
+            user=user,
+        )
+
+        self.assert_contains(
+            view,
+            [
+                '/panel/page/1/'
+            ]
+        )
+
+        for map in shown:
+            self.assert_contains(
+                view,
+                [
+                    map.title,
+                ]
+            )
+
+        for map in not_shown:
+            self.assert_doesnt_contain(
+                view,
+                [
+                    map.title,
+                ]
+            )

--- a/openra/urls.py
+++ b/openra/urls.py
@@ -86,10 +86,7 @@ urlpatterns = [
     url(r'^search/(?P<search_query>.+?)/?$', views.search, name='search'),
 
     url(r'^panel/?$', views.ControlPanel, name='ControlPanel'),
-    url(r'^panel/mymaps/?$', views.ControlPanel, name='ControlPanel'),
-    url(r'^panel/mymaps/page/(?P<page>\d+)/?$', views.ControlPanel, name='maps_paged'),
-    url(r'^panel/mymaps/page/(?P<page>\d+)/filter/(?P<filter>\w+)/?$', views.ControlPanel, name='maps_paged_filtered'),
-    url(r'^panel/mymaps/filter/(?P<filter>\w+)/?$', views.ControlPanel, name='maps_filtered'),
+    url(r'^panel/page/(?P<page>\d+)/?$', views.ControlPanel, name='maps_paged'),
 
     url(r'^faq/?$', views.faq, name='faq'),
     url(r'^contacts/?$', views.contacts, name='contacts'),

--- a/openra/views.py
+++ b/openra/views.py
@@ -147,14 +147,15 @@ def search(request, search_query="",
     )
 
 
-def ControlPanel(request, page=1, filter=""):
+def ControlPanel(request, page=1):
     if not request.user.is_authenticated():
         return HttpResponseRedirect('/login/')
-    perPage = 16
+
+    perPage = 20
     slice_start = perPage * int(page) - perPage
     slice_end = perPage * int(page)
     mapObject = Maps.objects.filter(user_id=request.user.id).filter(next_rev=0).order_by('-posted')
-    amount = len(mapObject)
+    amount = mapObject.count()
     rowsRange = int(math.ceil(amount / float(perPage)))   # amount of rows
     mapObject = mapObject[slice_start:slice_end]
     if len(mapObject) == 0 and int(page) != 1:
@@ -166,14 +167,14 @@ def ControlPanel(request, page=1, filter=""):
     template_args = {
         'content': 'control_panel.html',
         'request': request,
-        'title': 'My Content',
+        'title': content.titles['panel'],
         'maps': mapObject,
         'page': int(page),
         'range': [i + 1 for i in range(rowsRange)],
         'amount_maps': amount,
         'comments': comments,
     }
-    return StreamingHttpResponse(template.render(template_args, request))
+    return HttpResponse(template.render(template_args, request))
 
 
 def maps(request, page=1):


### PR DESCRIPTION
Adds tests for "/panel/" route.

Removed the "filter" route for "/panel/" as it wasn't used and didn't work.

Removed the "Screenshots" section from this page as it wasn't used and didn't work.

Updates the URLs slightly to be a bit shorter given the above.

Updated to use count() on the map lookup object rather than len(), which should be quicker and more resource efficient with high numbers of maps.

Updated to use HttpResponse rather than StreamingHttpResponse as that is what is recommended in the Django docs.

The actual pagination could probably be broken out at some point in the future, but I think that could maybe be done as its own thing once there are tests in place for the remaining functionality.