### PR TITLE
Sped up the maps page lookups and added option to return maps in json format

### DIFF
--- a/openra/content.py
+++ b/openra/content.py
@@ -13,4 +13,5 @@ titles = {
     'feed': 'OpenRA Resource Center - RSS Feed',
     'search': 'Search',
     'panel': 'My Maps',
+    'maps': 'Maps',
 }

--- a/openra/misc.py
+++ b/openra/misc.py
@@ -387,13 +387,13 @@ def map_filter(request, mapObject):
     ####################
     if selected_filter['sort_by'] and selected_filter['sort_by'] != 'latest':
         if selected_filter['sort_by'] == 'oldest':
-            mapObject = mapObject.order_by('-posted')
+            mapObject = mapObject.order_by('posted')
         elif selected_filter['sort_by'] == 'title':
             mapObject = mapObject.order_by('title')
         elif selected_filter['sort_by'] == 'title_reversed':
             mapObject = mapObject.order_by('-title')
         elif selected_filter['sort_by'] == 'players':
-            mapObject = mapObject.order_by('players')
+            mapObject = mapObject.order_by('-players')
         elif selected_filter['sort_by'] == 'lately_commented':
             mapObject = mapObject.extra({'last_comment': 'SELECT coalesce(MAX(posted), \'1990-01-01 00:00:00\') FROM openra_comments WHERE openra_comments.item_id = openra_maps.id AND openra_comments.item_type = \'maps\' AND openra_comments.is_removed = False' }).order_by('-last_comment')
         elif selected_filter['sort_by'] == 'rating':
@@ -403,7 +403,7 @@ def map_filter(request, mapObject):
         elif selected_filter['sort_by'] == 'downloads':
             mapObject = mapObject.order_by('-downloaded')
         elif selected_filter['sort_by'] == 'revisions':
-            mapObject = mapObject.order_by('revision')
+            mapObject = mapObject.order_by('-revision')
     else:
         mapObject = mapObject.order_by('-posted')
 

--- a/openra/misc.py
+++ b/openra/misc.py
@@ -386,33 +386,32 @@ def map_filter(request, mapObject):
     # Sorting
     ####################
     if selected_filter['sort_by'] and selected_filter['sort_by'] != 'latest':
-         if selected_filter['sort_by'] == 'oldest':
-             mapObject = mapObject.order_by('-posted')
-         elif selected_filter['sort_by'] == 'title':
-             mapObject = mapObject.order_by('title')
-         elif selected_filter['sort_by'] == 'title_reversed':
-             mapObject = mapObject.order_by('-title')
-         elif selected_filter['sort_by'] == 'players':
-             mapObject = mapObject.order_by('players')
-         elif selected_filter['sort_by'] == 'lately_commented':
-             mapObject = mapObject.extra({'last_comment': 'SELECT coalesce(MAX(posted), \'1990-01-01 00:00:00\') FROM openra_comments WHERE openra_comments.item_id = openra_maps.id AND openra_comments.item_type = \'maps\' AND openra_comments.is_removed = False' }).order_by('-last_comment')
-
-         elif selected_filter['sort_by'] == 'rating':
-             mapObject = mapObject.order_by('-rating')
-         elif selected_filter['sort_by'] == 'views':
-             mapObject = mapObject.order_by('-viewed')
-         elif selected_filter['sort_by'] == 'downloads':
-             mapObject = mapObject.order_by('-downloaded')
-         elif selected_filter['sort_by'] == 'revisions':
-             mapObject = mapObject.order_by('revision')
+        if selected_filter['sort_by'] == 'oldest':
+            mapObject = mapObject.order_by('-posted')
+        elif selected_filter['sort_by'] == 'title':
+            mapObject = mapObject.order_by('title')
+        elif selected_filter['sort_by'] == 'title_reversed':
+            mapObject = mapObject.order_by('-title')
+        elif selected_filter['sort_by'] == 'players':
+            mapObject = mapObject.order_by('players')
+        elif selected_filter['sort_by'] == 'lately_commented':
+            mapObject = mapObject.extra({'last_comment': 'SELECT coalesce(MAX(posted), \'1990-01-01 00:00:00\') FROM openra_comments WHERE openra_comments.item_id = openra_maps.id AND openra_comments.item_type = \'maps\' AND openra_comments.is_removed = False' }).order_by('-last_comment')
+        elif selected_filter['sort_by'] == 'rating':
+            mapObject = mapObject.order_by('-rating')
+        elif selected_filter['sort_by'] == 'views':
+            mapObject = mapObject.order_by('-viewed')
+        elif selected_filter['sort_by'] == 'downloads':
+            mapObject = mapObject.order_by('-downloaded')
+        elif selected_filter['sort_by'] == 'revisions':
+            mapObject = mapObject.order_by('revision')
     else:
-         mapObject = mapObject.order_by('-posted')
+        mapObject = mapObject.order_by('-posted')
 
     ###################
 
     return [mapObject, filter_prepare, selected_filter]
 
-def maps_to_list(mapsObject, base_uri):
+def prepare_maps_for_json(mapsObject, base_uri):
     mapsObject.prefetch_related('user')
     output = {}
     i = 0

--- a/openra/tests/routes/test_route_maps.py
+++ b/openra/tests/routes/test_route_maps.py
@@ -1,0 +1,91 @@
+from django.test import Client, override_settings
+import factory
+
+from openra import content
+from openra.tests.factories import MapsFactory, ScreenshotsFactory
+from openra.tests.routes.test_route_base import TestRouteBase
+
+
+class TestRouteMaps(TestRouteBase):
+
+    _route = '/maps'
+
+    def test_route_can_be_accessed_by_any_user(self):
+        self.assert_contains(
+            self.get(),
+            [
+                'Custom maps are stored in the user'
+            ],
+            title=content.titles['maps']
+        )
+
+    @override_settings(SITE_MAINTENANCE=True)
+    def test_route_shows_maintenance_page(self):
+        self.assert_is_maintenance(
+            self.get()
+        )
+
+    def test_route_shows_maps(self):
+        maps = [
+            MapsFactory(map_hash='mymap'),
+            MapsFactory(title='mymap'),
+            MapsFactory(info='mymap'),
+            MapsFactory(description='mymap'),
+            MapsFactory(author='mymap')
+        ]
+
+        titles = []
+
+        for map_model in maps:
+            titles.append(map_model.title)
+
+        self.assert_contains(
+            self.get(),
+            titles
+        )
+
+    def test_route_shows_maps_as_json(self):
+        maps = [
+            MapsFactory(map_hash='mymap'),
+            MapsFactory(title='mymap'),
+            MapsFactory(info='mymap'),
+            MapsFactory(description='mymap'),
+            MapsFactory(author='mymap')
+        ]
+
+        titles = []
+
+        for map_model in maps:
+            titles.append(map_model.title)
+
+        self.assert_contains(
+            self.get(route='/maps/json'),
+            titles
+        )
+
+    def test_route_allows_any_sort_by_option(self):
+        MapsFactory(map_hash='mymap'),
+        MapsFactory(title='mymap'),
+        MapsFactory(info='mymap'),
+        MapsFactory(description='mymap'),
+        MapsFactory(author='mymap')
+
+        titles = []
+
+        for sort in [
+            'latest',
+            'oldest',
+            'title',
+            'title_reversed',
+            'players',
+            'lately_commented',
+            'rating',
+            'views',
+            'downloads',
+            'revisions',
+        ]:
+            self.assert_contains(
+                self.get({
+                    'sort_by': sort
+                })
+            )

--- a/openra/tests/routes/test_route_maps.py
+++ b/openra/tests/routes/test_route_maps.py
@@ -59,7 +59,7 @@ class TestRouteMaps(TestRouteBase):
             titles.append(map_model.title)
 
         self.assert_contains(
-            self.get(route='/maps/json'),
+            self.get(route='/api/maps'),
             titles
         )
 
@@ -69,8 +69,6 @@ class TestRouteMaps(TestRouteBase):
         MapsFactory(info='mymap'),
         MapsFactory(description='mymap'),
         MapsFactory(author='mymap')
-
-        titles = []
 
         for sort in [
             'latest',
@@ -87,5 +85,6 @@ class TestRouteMaps(TestRouteBase):
             self.assert_contains(
                 self.get({
                     'sort_by': sort
-                })
+                }),
+                'Custom maps are stored in the user'
             )

--- a/openra/tests/routes/test_route_maps.py
+++ b/openra/tests/routes/test_route_maps.py
@@ -64,10 +64,10 @@ class TestRouteMaps(TestRouteBase):
         )
 
     def test_route_allows_any_sort_by_option(self):
-        MapsFactory(map_hash='mymap'),
-        MapsFactory(title='mymap'),
-        MapsFactory(info='mymap'),
-        MapsFactory(description='mymap'),
+        MapsFactory(map_hash='mymap')
+        MapsFactory(title='mymap')
+        MapsFactory(info='mymap')
+        MapsFactory(description='mymap')
         MapsFactory(author='mymap')
 
         for sort in [

--- a/openra/urls.py
+++ b/openra/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
 
     url(r'^maps/?$', views.maps, name='maps'),
+    url(r'^maps/json/?$', views.maps, {'output_format': 'json'}, name='maps'),
     url(r'^maps/(?P<arg>\d+)/?$', views.displayMap, name='displayMap'),
     url(r'^maps/(?P<arg>\d+)/minimap/?$', views.serveMinimap, name='serveMinimap'),
     url(r'^maps/(?P<arg>\d+)/oramap/?$', views.serveOramap, name='serveOramap'),

--- a/openra/urls.py
+++ b/openra/urls.py
@@ -29,7 +29,6 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
 
     url(r'^maps/?$', views.maps, name='maps'),
-    url(r'^maps/json/?$', views.maps, {'output_format': 'json'}, name='maps'),
     url(r'^maps/(?P<arg>\d+)/?$', views.displayMap, name='displayMap'),
     url(r'^maps/(?P<arg>\d+)/minimap/?$', views.serveMinimap, name='serveMinimap'),
     url(r'^maps/(?P<arg>\d+)/oramap/?$', views.serveOramap, name='serveOramap'),
@@ -104,6 +103,8 @@ urlpatterns = [
         url(r'^lastmap/?$', api.latest_map_info, name='mapAPI'),
         url(r'^(?P<map_hash>\w+)/?$', api.download_map, name='mapAPI_download'),
     ])),
+
+    url(r'^api/maps?$', views.maps, {'output_format': 'json'}, name='maps'),
 
     url(r'^favicon\.ico$', RedirectView.as_view(url='/static/favicon.ico')),
     url(r'^robots.txt$', views.robots, name='robots.txt'),

--- a/openra/views.py
+++ b/openra/views.py
@@ -192,7 +192,7 @@ def maps(request, page=1, output_format=""):
     amount_this_page = len(mapObject)
 
     if output_format == 'json':
-        return JsonResponse(misc.maps_to_list(mapObject, request.build_absolute_uri('/')))
+        return JsonResponse(misc.prepare_maps_for_json(mapObject, request.build_absolute_uri('/')))
 
     if amount_this_page == 0 and int(page) != 1:
         if request.META['QUERY_STRING']:


### PR DESCRIPTION
Updates the lookup for the maps page to use the database itself for any sorting and filtering instead of pulling all data down.

Adds some very basic testing to this path which can be extended when the code structure is updated.

Add a `/api/maps` url which allows map data to be returned in json format. At present this just takes the same GET parameters as the filters on the page, but this could be improved if needs be in the future.