### PR TITLE
Update maps api route to use its own resource format

### DIFF
--- a/openra/misc.py
+++ b/openra/misc.py
@@ -411,6 +411,32 @@ def map_filter(request, maps_query):
 
     return [maps_query, filter_prepare, selected_filter]
 
+def prepare_maps_for_json(maps_query):
+    maps_query.prefetch_related('user')
+    output = {}
+    i = 0
+    for current_map in maps_query:
+        output[i] = {
+            'id': current_map.id,
+            'posted': str(current_map.posted),
+            'uploader': current_map.user.username,
+            'title': current_map.title,
+            'description': current_map.description,
+            'info': current_map.info,
+            'author': current_map.author,
+            'players': current_map.players,
+            'game_mod': current_map.game_mod,
+            'map_hash': current_map.map_hash,
+            'width': current_map.width,
+            'height': current_map.height,
+            'bounds': current_map.bounds,
+            'advanced_map': current_map.advanced_map,
+            'lua': current_map.lua
+        }
+        i+=1
+
+    return output
+
 def user_account_age(user):
     """Returns the age of a user account in hours"""
     if not user or not user.is_authenticated():

--- a/openra/views.py
+++ b/openra/views.py
@@ -195,9 +195,7 @@ def maps(request, page=1, output_format=""):
     maps_query = maps_query[slice_start:slice_end]
 
     if output_format == 'json':
-        maps_query.prefetch_related('user')
-        from openra import api
-        return api.__map_info_from_objects(request, maps_query, False)
+        return JsonResponse(misc.prepare_maps_for_json(maps_query))
 
     amount_this_page = len(maps_query)
 


### PR DESCRIPTION
Update maps api route to use its own resource format as it was overly heavy and slow loading using the map resource format