### PR TITLE
Default to release when uploading maps

### DIFF
--- a/openra/static/style003.css
+++ b/openra/static/style003.css
@@ -1484,6 +1484,17 @@ p.registerInfo {
 	margin-top: 25px;
 }
 
+.upload-map-playtest-warning {
+    margin-bottom:10px;
+    color:#FF0000;
+    background:white;
+    background:#FFEEEE;
+    margin-right:10px;
+    padding:10px;
+    border:1px solid #ff3333;
+    display:none;
+}
+
 .upload-map-form-stars {
 	font-size: 0.9em;
 }

--- a/openra/static/style003.css
+++ b/openra/static/style003.css
@@ -1485,14 +1485,15 @@ p.registerInfo {
 }
 
 .upload-map-playtest-warning {
-    margin-bottom:10px;
-    color:#FF0000;
-    background:white;
-    background:#FFEEEE;
-    margin-right:10px;
-    padding:10px;
-    border:1px solid #ff3333;
-    display:none;
+    margin-bottom: 10px;
+    color: #FF0000;
+    background: white;
+    background: #FFEEEE;
+    margin-right: 10px;
+    padding: 10px;
+    border: 1px solid #ff3333;
+    display: none;
+
 }
 
 .upload-map-form-stars {

--- a/openra/templates/uploadMap.html
+++ b/openra/templates/uploadMap.html
@@ -13,7 +13,7 @@
 				return /^release-/.test(version);
 			}
 
-			$('.upload-map-form-parser option').filter(function(){
+			$('.upload-map-form-parser option').filter(function() {
 				return is_release_version(this.value)
 			}).first().attr("selected", "selected");
 

--- a/openra/templates/uploadMap.html
+++ b/openra/templates/uploadMap.html
@@ -9,7 +9,9 @@
 				$(".license_options").hide();
 			});
 
-			$('.upload-map-form-parser option:first-child').attr("selected", "selected");
+			$('.upload-map-form-parser option').filter(function(){
+				return /^release-/.test(this.value);
+			}).first().attr("selected", "selected");
 
 			$('.upload-map-form-parser option:first-child').append(' (latest version)')
 		});

--- a/openra/templates/uploadMap.html
+++ b/openra/templates/uploadMap.html
@@ -9,11 +9,20 @@
 				$(".license_options").hide();
 			});
 
+			function is_release_version(version) {
+				return /^release-/.test(version);
+			}
+
 			$('.upload-map-form-parser option').filter(function(){
-				return /^release-/.test(this.value);
+				return is_release_version(this.value)
 			}).first().attr("selected", "selected");
 
 			$('.upload-map-form-parser option:first-child').append(' (latest version)')
+
+			$('.upload-map-form-parser select').on('click change', function(e){
+
+				$('.upload-map-playtest-warning').toggle(!is_release_version(e.target.value))
+			})
 		});
 	</script>
 
@@ -38,6 +47,9 @@
 				</div>
 
 				<div class='upload-map-form-file'>
+					<div class="upload-map-playtest-warning">
+						Warning: You are uploading a map for a playtest. It will not be possible to update this automatically for the next release.
+					</div>
 					<input class="id_file" name="file" type="file">
 					<button type="submit">Upload</button>
 				</div>

--- a/openra/templates/uploadMap.html
+++ b/openra/templates/uploadMap.html
@@ -19,8 +19,7 @@
 
 			$('.upload-map-form-parser option:first-child').append(' (latest version)')
 
-			$('.upload-map-form-parser select').on('click change', function(e){
-
+			$('.upload-map-form-parser select').on('click change', function(e) {
 				$('.upload-map-playtest-warning').toggle(!is_release_version(e.target.value))
 			})
 		});


### PR DESCRIPTION
Default to using the latest "release" version when uploading maps, as that's the general use case except when explicitly testing a playtest. This is because there is no upgrade path from playtests.

Also adds a notice warning users when uploading a map to playtest