### PR TITLE
Break out remaining routes that post to display map

### DIFF
--- a/openra/content.py
+++ b/openra/content.py
@@ -9,6 +9,7 @@ titles = {
     'home': '',
     'login': 'Sign In',
     'logout': 'Sign Out',
+    'user_actions_blocked': 'Account Blocked',
     # TODO reformat like others
     'feed': 'OpenRA Resource Center - RSS Feed',
     'search': 'Search',

--- a/openra/templates/displayMap.html
+++ b/openra/templates/displayMap.html
@@ -237,7 +237,7 @@
 
 		{% if request.user.is_authenticated %}
 			<div class='cBlock'>
-				<form class='post_comment' method='POST' action='{{request.path}}#comments'>{% csrf_token %}
+				<form class='post_comment' method='POST' action='/maps/{{map.id}}/post-comment'>{% csrf_token %}
 					<textarea name='comment'></textarea>
 					<input type='submit' value="Comment" class='button'>
 				</form>

--- a/openra/templates/new_user_action_blocked.html
+++ b/openra/templates/new_user_action_blocked.html
@@ -6,5 +6,9 @@
 
 <div class="cBlock_comments">
 	<p style="margin-top: 0px">User accounts must be one day old before they can post content.</p>
-	<p>Please try again in {{hours_remaining}} hours.</p>
+    {% if account_blocked %}
+        <p>Please try again in {{hours_remaining}} hours.</p>
+    {% else %}
+        <p>Your block is over, please try again now.</p>
+    {% endif %}
 </div>

--- a/openra/tests/routes/test_route_base.py
+++ b/openra/tests/routes/test_route_base.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, Client, override_settings
 
 from openra.tests.factories import UserFactory
+from django.utils import timezone
 
 
 @override_settings(SITE_MAINTENANCE=False)
@@ -42,6 +43,11 @@ class TestRouteBase(TestCase):
             user if user else UserFactory()
         )
         return self._post(client, data, route)
+
+    def create_old_user(self):
+        return UserFactory(
+            date_joined=timezone.datetime(1996, 11, 29, 0, 0)
+        )
 
     def assert_contains(self, response, contents=[],
                         status_code=200,

--- a/openra/tests/routes/test_route_maps_post_comment.py
+++ b/openra/tests/routes/test_route_maps_post_comment.py
@@ -1,0 +1,128 @@
+from django.test import Client, override_settings
+import factory
+from registration.forms import User
+
+from openra import content
+from openra.models import Comments, Reports
+from openra.tests.factories import MapsFactory, ReportsFactory, ScreenshotsFactory, UserFactory
+from openra.tests.routes.test_route_base import TestRouteBase
+
+
+class TestRouteMapsPostComment(TestRouteBase):
+
+    _route = '/maps/{}/post-comment'
+
+    def test_route_can_be_accessed_by_any_user(self):
+        user = self.create_old_user()
+        map = MapsFactory()
+
+        response = self.post_authed(
+            {
+                'comment': 'Comment'
+            },
+            user,
+            self._route.format(map.id)
+        )
+
+        self.assertEquals(
+            302,
+            response.status_code
+        )
+
+        self.assertEquals(
+            '/maps/' + str(map.id) + '/#comments',
+            response.url
+        )
+
+    @override_settings(SITE_MAINTENANCE=True)
+    def test_route_shows_maintenance_page(self):
+        map = MapsFactory()
+        self.assert_is_maintenance(
+            self.get(
+                {},
+                self._route.format(map.id)
+            ),
+        )
+
+    def test_route_redirects_to_login_if_not_authed(self):
+        map = MapsFactory()
+
+        response = self.post(
+            {
+                'comment': 'Comment'
+            },
+            self._route.format(map.id)
+        )
+
+        self.assertEquals(
+            302,
+            response.status_code
+        )
+
+        self.assertEquals(
+            '/login/',
+            response.url
+        )
+
+        self.assertEquals(
+            0,
+            Comments.objects.count()
+        )
+
+    def test_it_redirects_to_actions_blocked_if_new_account(self):
+        map = MapsFactory()
+
+        response = self.post_authed(
+            {
+                'comment': 'Comment'
+            },
+            None,
+            self._route.format(map.id)
+        )
+
+        self.assertEquals(
+            302,
+            response.status_code
+        )
+
+        self.assertEquals(
+            '/accounts/actions-blocked',
+            response.url
+        )
+
+        self.assertEquals(
+            0,
+            Comments.objects.count()
+        )
+
+    def test_it_can_add_a_comment(self):
+        user = self.create_old_user()
+        map = MapsFactory()
+
+        self.assertEquals(
+            0,
+            Comments.objects.count()
+        )
+
+        response = self.post_authed(
+            {
+                'comment': 'Comment'
+            },
+            user,
+            self._route.format(map.id)
+        )
+
+        self.assertEquals(
+            302,
+            response.status_code
+        )
+
+        self.assertEquals(
+            '/maps/' + str(map.id) + '/#comments',
+            response.url
+        )
+
+        self.assertEquals(
+            1,
+            Comments.objects.count()
+        )

--- a/openra/tests/routes/test_route_user_actions_blocked.py
+++ b/openra/tests/routes/test_route_user_actions_blocked.py
@@ -1,0 +1,87 @@
+from django.test import Client, override_settings
+import factory
+from registration.forms import User
+
+from openra import content
+from openra.models import Reports
+from openra.tests.factories import MapsFactory, ReportsFactory, ScreenshotsFactory, UserFactory
+from openra.tests.routes.test_route_base import TestRouteBase
+
+
+class TestRouteUserActionsBlocked(TestRouteBase):
+
+    _route = '/accounts/actions-blocked'
+
+    def test_route_can_be_accessed_by_any_user(self):
+        user = UserFactory()
+
+        response = self.get_authed(
+            {},
+            user
+        )
+
+        self.assert_contains(
+            response,
+            [
+
+                'User accounts must be one day old'
+            ],
+            title=content.titles['user_actions_blocked']
+        )
+
+    @override_settings(SITE_MAINTENANCE=True)
+    def test_route_shows_maintenance_page(self):
+        map = MapsFactory()
+        self.assert_is_maintenance(
+            self.get(
+                {},
+                self._route.format(map.id)
+            ),
+        )
+
+    def test_route_redirects_to_login_if_not_authed(self):
+        map = MapsFactory()
+
+        response = self.get()
+
+        self.assertEquals(
+            302,
+            response.status_code
+        )
+
+        self.assertEquals(
+            '/login/',
+            response.url
+        )
+
+    def test_will_show_time_remaining_if_blocked(self):
+        user = UserFactory()
+
+        response = self.get_authed(
+            {},
+            user
+        )
+
+        self.assert_contains(
+            response,
+            [
+                '24 hours'
+            ],
+            title=content.titles['user_actions_blocked']
+        )
+
+    def test_can_show_when_block_it_over(self):
+        user = self.create_old_user()
+
+        response = self.get_authed(
+            {},
+            user
+        )
+
+        self.assert_contains(
+            response,
+            [
+                'block is over'
+            ],
+            title=content.titles['user_actions_blocked']
+        )

--- a/openra/urls.py
+++ b/openra/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     url(r'^maps/(?P<map_id>\d+)/report', views.map_report, name='map_report'),
     url(r'^maps/(?P<map_id>\d+)/update-map-info', views.map_update_map_info, name='map_update_map_info'),
     url(r'^maps/(?P<map_id>\d+)/upload-screenshot', views.map_upload_screenshot, name='map_upload_screenshot'),
+    url(r'^maps/(?P<map_id>\d+)/post-comment', views.map_post_comment, name='map_post_comment'),
 
     url(r'^upload/map/?$', views.uploadMap, name='uploadMap'),
     url(r'^upload/map/(?P<previous_rev>\d+)/?$', views.uploadMap, name='uploadMap'),
@@ -78,6 +79,7 @@ urlpatterns = [
 
     url(r'^accounts/', include('allauth.urls')),
     url(r'^accounts/profile/?$', views.profile, name='profile'),
+    url(r'^accounts/actions-blocked/?$', views.user_actions_blocked, name='actionsBlocked'),
 
 
     url(r'^news/feed.rss?$', views.feed, name='feed'),


### PR DESCRIPTION
Moves account blocked to its own route from "display map" so that it can be linked to if needed and so it is isolated for testing.

Moves post comment to its own route from "display map" to make it more easily testable and prevent form resubmission issues.